### PR TITLE
Enhance workflow notifications and inventory safeguards

### DIFF
--- a/app/Models/WorkflowNotification.php
+++ b/app/Models/WorkflowNotification.php
@@ -16,12 +16,20 @@ class WorkflowNotification extends Model
         'type',
         'channel',
         'message',
+        'metadata',
         'is_sent',
+        'delivery_status',
+        'priority',
+        'delivered_at',
+        'read_at',
         'sent_at',
     ];
 
     protected $casts = [
         'is_sent' => 'boolean',
+        'metadata' => 'array',
+        'delivered_at' => 'datetime',
+        'read_at' => 'datetime',
         'sent_at' => 'datetime',
     ];
 
@@ -50,11 +58,25 @@ class WorkflowNotification extends Model
         return $query->where('is_sent', true);
     }
 
+    public function scopeUnread($query)
+    {
+        return $query->whereNull('read_at');
+    }
+
     public function markAsSent(): void
     {
         $this->update([
             'is_sent' => true,
+            'delivery_status' => 'delivered',
+            'delivered_at' => now(),
             'sent_at' => now(),
+        ]);
+    }
+
+    public function markAsRead(): void
+    {
+        $this->update([
+            'read_at' => now(),
         ]);
     }
 }

--- a/app/Services/WorkflowService.php
+++ b/app/Services/WorkflowService.php
@@ -368,6 +368,11 @@ class WorkflowService
             'type' => 'approval_request',
             'channel' => 'system',
             'message' => "You have a pending approval request for {$approval->stage_name}",
+            'priority' => 'high',
+            'metadata' => [
+                'stage_order' => $approval->stage_order,
+                'stage_name' => $approval->stage_name,
+            ],
         ]);
     }
 
@@ -384,6 +389,11 @@ class WorkflowService
             'type' => $type,
             'channel' => 'system',
             'message' => "Your workflow request has been {$status}",
+            'priority' => $status === 'approved' ? 'normal' : 'high',
+            'metadata' => [
+                'final_stage' => $instance->current_stage,
+                'status' => $status,
+            ],
         ]);
     }
 

--- a/database/migrations/2025_12_31_000001_update_workflow_notification_constraints.php
+++ b/database/migrations/2025_12_31_000001_update_workflow_notification_constraints.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Preserve workflow history when branches or approvals are removed
+        Schema::table('workflow_instances', function (Blueprint $table) {
+            if (Schema::hasColumn('workflow_instances', 'branch_id')) {
+                $table->dropForeign(['branch_id']);
+                $table->foreign('branch_id')
+                    ->references('id')
+                    ->on('branches')
+                    ->nullOnDelete();
+            }
+        });
+
+        Schema::table('workflow_notifications', function (Blueprint $table) {
+            if (Schema::hasColumn('workflow_notifications', 'workflow_approval_id')) {
+                $table->dropForeign(['workflow_approval_id']);
+                $table->foreign('workflow_approval_id')
+                    ->references('id')
+                    ->on('workflow_approvals')
+                    ->nullOnDelete();
+            }
+
+            if (! Schema::hasColumn('workflow_notifications', 'delivery_status')) {
+                $table->string('delivery_status')->default('pending')->after('is_sent');
+            }
+
+            if (! Schema::hasColumn('workflow_notifications', 'priority')) {
+                $table->string('priority')->default('normal')->after('delivery_status');
+            }
+
+            if (! Schema::hasColumn('workflow_notifications', 'delivered_at')) {
+                $table->timestamp('delivered_at')->nullable()->after('priority');
+            }
+
+            if (! Schema::hasColumn('workflow_notifications', 'read_at')) {
+                $table->timestamp('read_at')->nullable()->after('delivered_at');
+            }
+
+            if (! Schema::hasColumn('workflow_notifications', 'metadata')) {
+                $table->json('metadata')->nullable()->after('message');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('workflow_notifications', function (Blueprint $table) {
+            if (Schema::hasColumn('workflow_notifications', 'workflow_approval_id')) {
+                $table->dropForeign(['workflow_approval_id']);
+                $table->foreign('workflow_approval_id')
+                    ->references('id')
+                    ->on('workflow_approvals')
+                    ->onDelete('cascade');
+            }
+
+            foreach (['metadata', 'read_at', 'delivered_at', 'priority', 'delivery_status'] as $column) {
+                if (Schema::hasColumn('workflow_notifications', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+
+        Schema::table('workflow_instances', function (Blueprint $table) {
+            if (Schema::hasColumn('workflow_instances', 'branch_id')) {
+                $table->dropForeign(['branch_id']);
+                $table->foreign('branch_id')
+                    ->references('id')
+                    ->on('branches')
+                    ->onDelete('cascade');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Adjust workflow workflow instance and notification foreign keys to preserve history and add delivery metadata fields
- Extend notification model/service usage with priorities, metadata, and read/delivery tracking
- Harden reorder calculations to avoid zero-cost math errors and provide safe estimated costs

## Testing
- php -l app/Models/WorkflowNotification.php
- php -l app/Services/WorkflowService.php
- php -l app/Services/WorkflowAutomationService.php
- php -l database/migrations/2025_12_31_000001_update_workflow_notification_constraints.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694492360e788332a64943045d7cb2e3)