### PR TITLE
Enhance pricing metadata and secure query utilities

### DIFF
--- a/app/Models/PriceGroup.php
+++ b/app/Models/PriceGroup.php
@@ -4,20 +4,27 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class PriceGroup extends BaseModel
 {
     protected ?string $moduleKey = 'pricing';
 
-    protected $fillable = ['name', 'description', 'extra_attributes'];
+    protected $fillable = ['branch_id', 'code', 'name', 'description', 'is_active', 'extra_attributes'];
 
     protected $casts = [
+        'is_active' => 'bool',
         'extra_attributes' => 'array',
     ];
 
     public function customers(): HasMany
     {
         return $this->hasMany(Customer::class);
+    }
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
     }
 }

--- a/app/Models/Tax.php
+++ b/app/Models/Tax.php
@@ -4,11 +4,23 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 class Tax extends BaseModel
 {
     protected ?string $moduleKey = 'pricing';
 
-    protected $fillable = ['name', 'rate', 'type', 'is_inclusive', 'extra_attributes'];
+    protected $fillable = ['branch_id', 'code', 'name', 'description', 'rate', 'type', 'is_inclusive', 'is_active', 'extra_attributes'];
 
-    protected $casts = ['rate' => 'decimal:4', 'is_inclusive' => 'bool'];
+    protected $casts = [
+        'rate' => 'decimal:4',
+        'is_inclusive' => 'bool',
+        'is_active' => 'bool',
+        'extra_attributes' => 'array',
+    ];
+
+    public function branch(): BelongsTo
+    {
+        return $this->belongsTo(Branch::class);
+    }
 }

--- a/database/migrations/2025_12_19_000001_enhance_price_groups_and_taxes.php
+++ b/database/migrations/2025_12_19_000001_enhance_price_groups_and_taxes.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('price_groups')) {
+            Schema::table('price_groups', function (Blueprint $table) {
+                if (! Schema::hasColumn('price_groups', 'branch_id')) {
+                    $table->unsignedBigInteger('branch_id')->nullable()->after('id');
+                    $table->foreign('branch_id')->references('id')->on('branches')->onDelete('set null');
+                }
+
+                if (! Schema::hasColumn('price_groups', 'code')) {
+                    $table->string('code', 50)->nullable()->after('name');
+                    $table->unique('code');
+                }
+
+                if (! Schema::hasColumn('price_groups', 'is_active')) {
+                    $table->boolean('is_active')->default(true)->after('description');
+                }
+
+                if (! Schema::hasColumn('price_groups', 'extra_attributes')) {
+                    $table->json('extra_attributes')->nullable()->after('is_active');
+                }
+            });
+        }
+
+        if (Schema::hasTable('taxes')) {
+            Schema::table('taxes', function (Blueprint $table) {
+                if (! Schema::hasColumn('taxes', 'branch_id')) {
+                    $table->unsignedBigInteger('branch_id')->nullable()->after('id');
+                    $table->foreign('branch_id')->references('id')->on('branches')->onDelete('set null');
+                }
+
+                if (! Schema::hasColumn('taxes', 'code')) {
+                    $table->string('code', 50)->nullable()->after('name');
+                    $table->unique('code');
+                }
+
+                if (! Schema::hasColumn('taxes', 'description')) {
+                    $table->text('description')->nullable()->after('code');
+                }
+
+                if (! Schema::hasColumn('taxes', 'is_active')) {
+                    $table->boolean('is_active')->default(true)->after('is_inclusive');
+                }
+
+                if (! Schema::hasColumn('taxes', 'extra_attributes')) {
+                    $table->json('extra_attributes')->nullable()->after('is_active');
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('price_groups')) {
+            Schema::table('price_groups', function (Blueprint $table) {
+                if (Schema::hasColumn('price_groups', 'code')) {
+                    $table->dropUnique('price_groups_code_unique');
+                    $table->dropColumn('code');
+                }
+
+                if (Schema::hasColumn('price_groups', 'branch_id')) {
+                    $table->dropForeign(['branch_id']);
+                    $table->dropColumn('branch_id');
+                }
+
+                if (Schema::hasColumn('price_groups', 'is_active')) {
+                    $table->dropColumn('is_active');
+                }
+
+                if (Schema::hasColumn('price_groups', 'extra_attributes')) {
+                    $table->dropColumn('extra_attributes');
+                }
+            });
+        }
+
+        if (Schema::hasTable('taxes')) {
+            Schema::table('taxes', function (Blueprint $table) {
+                if (Schema::hasColumn('taxes', 'code')) {
+                    $table->dropUnique('taxes_code_unique');
+                    $table->dropColumn('code');
+                }
+
+                if (Schema::hasColumn('taxes', 'description')) {
+                    $table->dropColumn('description');
+                }
+
+                if (Schema::hasColumn('taxes', 'branch_id')) {
+                    $table->dropForeign(['branch_id']);
+                    $table->dropColumn('branch_id');
+                }
+
+                if (Schema::hasColumn('taxes', 'is_active')) {
+                    $table->dropColumn('is_active');
+                }
+
+                if (Schema::hasColumn('taxes', 'extra_attributes')) {
+                    $table->dropColumn('extra_attributes');
+                }
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add branch ownership, codes, activation flags, and metadata support to price groups and taxes
- extend PriceGroup and Tax models with casts and branch relationships for the new pricing fields
- harden query optimization utilities by validating identifiers, limiting driver support, and sanitizing EXPLAIN/OPTIMIZE statements

## Testing
- php -l app/Services/Performance/QueryOptimizationService.php
- php -l app/Models/PriceGroup.php
- php -l app/Models/Tax.php
- php -l database/migrations/2025_12_19_000001_enhance_price_groups_and_taxes.php
- phpunit *(fails: phpunit/vendor binaries not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694492360e788332a64943045d7cb2e3)