### PR TITLE
Fix project task parent mapping and timelog task listing

### DIFF
--- a/app/Livewire/Projects/Tasks.php
+++ b/app/Livewire/Projects/Tasks.php
@@ -71,6 +71,7 @@ class Tasks extends Component
             'priority', 'status', 'start_date', 'due_date',
             'estimated_hours', 'progress'
         ]));
+        $this->parent_task_id = $this->editingTask->parent_id;
         $this->selectedDependencies = $this->editingTask->dependencies()->pluck('dependency_id')->toArray();
     }
 
@@ -84,6 +85,9 @@ class Tasks extends Component
             'priority', 'status', 'start_date', 'due_date',
             'estimated_hours', 'progress'
         ]);
+
+        $data['parent_id'] = $data['parent_task_id'];
+        unset($data['parent_task_id']);
 
         if ($this->editingTask) {
             $this->editingTask->update($data);

--- a/app/Livewire/Projects/TimeLogs.php
+++ b/app/Livewire/Projects/TimeLogs.php
@@ -133,7 +133,7 @@ class TimeLogs extends Component
             ->orderByRaw('COALESCE(log_date, date) desc')
             ->paginate(15);
 
-        $tasks = $this->project->tasks()->orderBy('title')->get();
+        $tasks = $this->project->tasks()->orderBy('name')->get();
         $employees = User::orderBy('name')->get();
 
         $totalHours = $this->project->timeLogs()->sum('hours');


### PR DESCRIPTION
## Summary
- map parent task selections to the model's parent_id so updates and creates persist correctly
- order project tasks by their name column when building timelog dropdowns to avoid invalid SQL

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69450e2212d483328759268d0429c4d2)