### PR TITLE
Fix rounding promotion in byte formatter

### DIFF
--- a/app/Services/UIHelperService.php
+++ b/app/Services/UIHelperService.php
@@ -191,14 +191,14 @@ class UIHelperService
             $i++;
         }
 
-        // Round before formatting to check for promotion using bcmath
-        $rounded = (float) bcdiv((string) $value, '1', $precision);
+        // Round before formatting to check for promotion
+        $rounded = round($value, $precision);
 
         // If rounded value is 1024 or more, promote to next unit
         if ($rounded >= 1024 && $i < count($units) - 1) {
-            $value = (float) bcdiv((string) $rounded, '1024', $precision + 2);
+            $value = $rounded / 1024;
             $i++;
-            $rounded = (float) bcdiv((string) $value, '1', $precision);
+            $rounded = round($value, $precision);
         }
 
         // Format the value without thousand separators and remove trailing zeros


### PR DESCRIPTION
## Summary
- correct rounding when converting bytes to larger units
- ensure values that round to 1024 are promoted to the next unit

## Testing
- not run (environment not set up)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69451067dcc8833291491ef096d7582d)