### PR TITLE
Improve settings validation and sidebar permissions

### DIFF
--- a/app/Services/ModuleNavigationService.php
+++ b/app/Services/ModuleNavigationService.php
@@ -71,6 +71,8 @@ class ModuleNavigationService
             'label' => $item->localized_label,
             'route' => $item->route_name,
             'icon' => $item->icon,
+            'permission' => $item->required_permissions[0] ?? null,
+            'permissions' => $item->required_permissions ?? [],
             'module_id' => $item->module_id,
             'module_key' => $item->module?->key,
             'children' => [],

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -38,17 +38,29 @@
             return true;
         }
 
+        if (is_array($permission)) {
+            foreach ($permission as $perm) {
+                if ($perm && ! $user->can($perm)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         return $user->can($permission);
     };
 
     $mapNavItem = null;
     $mapNavItem = function (array $item) use (&$mapNavItem) {
+        $children = collect($item['children'] ?? [])->map($mapNavItem)->values()->all();
+
         return [
             'route' => $item['route'] ?? null,
             'icon' => $item['icon'] ?? '🧭',
             'label' => $item['label'] ?? __('Navigation'),
-            'permission' => null,
-            'children' => collect($item['children'] ?? [])->map($mapNavItem)->values()->all(),
+            'permission' => $item['permissions'] ?? ($item['permission'] ?? null),
+            'children' => $children,
         ];
     };
 

--- a/resources/views/livewire/admin/settings/system-settings.blade.php
+++ b/resources/views/livewire/admin/settings/system-settings.blade.php
@@ -38,6 +38,12 @@
                 <div class="px-4 py-3">
                     <form wire:submit.prevent="save" class="space-y-3">
 
+                        @if($errors->any())
+                            <div class="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 shadow-sm dark:border-red-700/70 dark:bg-red-900/40 dark:text-red-50">
+                                {{ __('Please fix the highlighted setting keys before saving.') }}
+                            </div>
+                        @endif
+
                         <div class="border border-slate-200/70 dark:border-slate-700/70 rounded-xl overflow-hidden bg-white/80 dark:bg-slate-900/80">
                             <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700 text-xs sm:text-sm">
                                 <thead class="bg-slate-50/90 dark:bg-slate-800/70">
@@ -67,6 +73,9 @@
                                                        wire:model="rows.{{ $index }}.key"
                                                        placeholder="app.locale"
                                                        class="w-full rounded-md border border-slate-200/80 dark:border-slate-700/70 bg-white/80 dark:bg-slate-900/80 px-2 py-1 text-xs sm:text-sm text-slate-900 dark:text-slate-100 focus:outline-none focus:ring-1 focus:ring-emerald-500 focus:border-emerald-500">
+                                                @error("rows.$index.key")
+                                                    <p class="mt-1 text-[11px] font-medium text-red-600 dark:text-red-300">{{ $message }}</p>
+                                                @enderror
                                             </td>
                                             <td class="px-3 py-2 align-top">
                                                 <input type="text"


### PR DESCRIPTION
## Summary
- add authorization and duplicate-key validation when saving system settings
- surface inline validation feedback in the system settings Livewire form
- preserve module navigation permissions so sidebar respects multi-permission items

## Testing
- `php -l app/Livewire/Admin/Settings/SystemSettings.php`
- `php -l app/Services/ModuleNavigationService.php`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694515bedce88332bbc4a4851c9cd0c8)