### PR TITLE
Fix module navigation foreign key handling

### DIFF
--- a/database/migrations/2025_12_07_215100_make_module_navigation_module_id_nullable.php
+++ b/database/migrations/2025_12_07_215100_make_module_navigation_module_id_nullable.php
@@ -14,9 +14,10 @@ return new class extends Migration
         Schema::table('module_navigation', function (Blueprint $table) {
             // Drop the foreign key constraint first
             $table->dropForeign(['module_id']);
-            
-            // Make module_id nullable
-            $table->foreignId('module_id')->nullable()->change()->constrained('modules')->cascadeOnDelete();
+
+            // Make module_id nullable and re-apply proper foreign key behavior
+            $table->unsignedBigInteger('module_id')->nullable()->change();
+            $table->foreign('module_id')->references('id')->on('modules')->nullOnDelete();
         });
     }
 
@@ -28,9 +29,10 @@ return new class extends Migration
         Schema::table('module_navigation', function (Blueprint $table) {
             // Drop the foreign key
             $table->dropForeign(['module_id']);
-            
+
             // Make module_id not nullable again
-            $table->foreignId('module_id')->change()->constrained('modules')->cascadeOnDelete();
+            $table->unsignedBigInteger('module_id')->change();
+            $table->foreign('module_id')->references('id')->on('modules')->cascadeOnDelete();
         });
     }
 };


### PR DESCRIPTION
## Summary
- fix module_navigation module_id migration to change column nullability safely
- reapply foreign key with null-on-delete behavior matching schema intent

## Testing
- php -l database/migrations/2025_12_07_215100_make_module_navigation_module_id_nullable.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694517c2b4bc833285a525c6bb1dc08f)