### PR TITLE
Harden search, attachment, and store token authorization

### DIFF
--- a/app/Http/Controllers/Attachments/DownloadController.php
+++ b/app/Http/Controllers/Attachments/DownloadController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Attachments;
+
+use App\Http\Controllers\Controller;
+use App\Models\Attachment;
+use App\Services\AttachmentAuthorizationService;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DownloadController extends Controller
+{
+    public function __construct(private AttachmentAuthorizationService $authorizer)
+    {
+    }
+
+    public function __invoke(Attachment $attachment): StreamedResponse
+    {
+        $user = Auth::user();
+        abort_unless($user, 403);
+
+        $this->authorizer->authorizeForAttachment($user, $attachment);
+
+        abort_unless(Storage::disk($attachment->disk)->exists($attachment->path), 404);
+
+        $disposition = $attachment->isImage() || $attachment->isPdf() ? 'inline' : 'attachment';
+
+        return Storage::disk($attachment->disk)->response(
+            $attachment->path,
+            $attachment->original_filename,
+            [
+                'Content-Type' => $attachment->mime_type,
+                'Content-Disposition' => $disposition.'; filename="'.addslashes($attachment->original_filename).'"',
+            ]
+        );
+    }
+}

--- a/app/Http/Middleware/AuthenticateStoreToken.php
+++ b/app/Http/Middleware/AuthenticateStoreToken.php
@@ -47,6 +47,13 @@ class AuthenticateStoreToken
             ], 403);
         }
 
+        if (empty($abilities) && ! $storeToken->hasAbility('*')) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This endpoint requires explicit token abilities.',
+            ], 403);
+        }
+
         foreach ($abilities as $ability) {
             if (! $storeToken->hasAbility($ability)) {
                 return response()->json([

--- a/app/Models/Attachment.php
+++ b/app/Models/Attachment.php
@@ -54,7 +54,7 @@ class Attachment extends Model
 
     public function getUrlAttribute(): string
     {
-        return Storage::disk($this->disk)->url($this->path);
+        return route('attachments.download', $this);
     }
 
     public function getHumanSizeAttribute(): string

--- a/app/Models/SearchIndex.php
+++ b/app/Models/SearchIndex.php
@@ -51,16 +51,20 @@ class SearchIndex extends BaseModel
     /**
      * Search across all indexed content.
      */
-    public static function search(string $query, ?int $branchId = null, ?string $module = null, int $limit = 20): array
+    public static function search(string $query, int $branchId, array|string|null $module = null, int $limit = 20): array
     {
-        $builder = static::query();
-
-        if ($branchId) {
-            $builder->where('branch_id', $branchId);
-        }
+        $builder = static::query()->where('branch_id', $branchId);
 
         if ($module) {
-            $builder->where('module', $module);
+            if (is_array($module)) {
+                if (empty($module)) {
+                    return [];
+                }
+
+                $builder->whereIn('module', $module);
+            } else {
+                $builder->where('module', $module);
+            }
         }
 
         // Use full-text search if available

--- a/app/Services/AttachmentAuthorizationService.php
+++ b/app/Services/AttachmentAuthorizationService.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Attachment;
+use App\Models\Branch;
+use App\Models\Customer;
+use App\Models\Document;
+use App\Models\HREmployee;
+use App\Models\Product;
+use App\Models\Purchase;
+use App\Models\RentalContract;
+use App\Models\Sale;
+use App\Models\Supplier;
+use App\Models\User;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Gate;
+
+class AttachmentAuthorizationService
+{
+    /**
+     * Map attachable models to their required base permission.
+     *
+     * @var array<class-string,string>
+     */
+    private const ATTACHABLE_PERMISSIONS = [
+        Branch::class => 'branches.view',
+        Customer::class => 'customers.view',
+        Supplier::class => 'suppliers.view',
+        Product::class => 'inventory.products.view',
+        Sale::class => 'sales.view',
+        Purchase::class => 'purchases.view',
+        RentalContract::class => 'rental.contracts.view',
+        HREmployee::class => 'hrm.employees.view',
+        Document::class => 'documents.view',
+    ];
+
+    /**
+     * @param class-string $modelType
+     *
+     * @throws AuthorizationException
+     */
+    public function authorizeForModel(Authenticatable|User $user, string $modelType, int $modelId): object
+    {
+        $modelClass = ltrim($modelType, '\\');
+
+        if (! array_key_exists($modelClass, self::ATTACHABLE_PERMISSIONS)) {
+            throw new AuthorizationException('Unsupported resource.');
+        }
+
+        /** @var object $attachable */
+        $attachable = $modelClass::findOrFail($modelId);
+
+        $this->authorizeModel($user, $attachable);
+
+        return $attachable;
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    public function authorizeForAttachment(Authenticatable|User $user, Attachment $attachment): object
+    {
+        $attachable = $attachment->attachable;
+
+        if (! $attachable) {
+            throw new AuthorizationException('Attachment is orphaned.');
+        }
+
+        $this->authorizeModel($user, $attachable);
+
+        return $attachable;
+    }
+
+    /**
+     * @throws AuthorizationException
+     */
+    private function authorizeModel(Authenticatable|User $user, object $attachable): void
+    {
+        $modelClass = get_class($attachable);
+
+        if (! array_key_exists($modelClass, self::ATTACHABLE_PERMISSIONS)) {
+            throw new AuthorizationException('Unsupported resource.');
+        }
+
+        $permission = self::ATTACHABLE_PERMISSIONS[$modelClass];
+
+        if (! $user->can($permission)) {
+            throw new AuthorizationException('Forbidden');
+        }
+
+        if (isset($attachable->branch_id) && $user->branch_id && $attachable->branch_id !== $user->branch_id) {
+            throw new AuthorizationException('Forbidden');
+        }
+
+        if (Gate::getPolicyFor($attachable)) {
+            Gate::forUser($user)->authorize('view', $attachable);
+        }
+    }
+}

--- a/app/Services/DocumentService.php
+++ b/app/Services/DocumentService.php
@@ -126,6 +126,7 @@ class DocumentService
                 'file_path' => $path,
                 'file_size' => $file->getSize(),
                 'mime_type' => $file->getMimeType(),
+                'file_type' => $file->getClientOriginalExtension(),
             ]);
 
             // Log activity

--- a/resources/views/livewire/components/notes-attachments.blade.php
+++ b/resources/views/livewire/components/notes-attachments.blade.php
@@ -119,7 +119,7 @@
                             </div>
                         </div>
                         <div class="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <a href="{{ $attachment['url'] }}" target="_blank" class="p-1.5 text-slate-400 hover:text-blue-500" title="{{ __('Download') }}">
+                            <a href="{{ $attachment['url'] }}" class="p-1.5 text-slate-400 hover:text-blue-500" title="{{ __('Download') }}">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                                 </svg>

--- a/routes/api.php
+++ b/routes/api.php
@@ -47,38 +47,38 @@ Route::prefix('v1')->group(function () {
         });
     });
 
-    Route::middleware(['store.token', 'throttle:api'])->group(function () {
+    Route::middleware(['throttle:api'])->group(function () {
         Route::prefix('products')->group(function () {
-            Route::get('/', [ProductsController::class, 'index']);
-            Route::post('/', [ProductsController::class, 'store']);
-            Route::get('/external/{externalId}', [ProductsController::class, 'byExternalId']);
-            Route::get('/{id}', [ProductsController::class, 'show']);
-            Route::put('/{id}', [ProductsController::class, 'update']);
-            Route::delete('/{id}', [ProductsController::class, 'destroy']);
+            Route::get('/', [ProductsController::class, 'index'])->middleware('store.token:products.read');
+            Route::post('/', [ProductsController::class, 'store'])->middleware('store.token:products.write');
+            Route::get('/external/{externalId}', [ProductsController::class, 'byExternalId'])->middleware('store.token:products.read');
+            Route::get('/{id}', [ProductsController::class, 'show'])->middleware('store.token:products.read');
+            Route::put('/{id}', [ProductsController::class, 'update'])->middleware('store.token:products.write');
+            Route::delete('/{id}', [ProductsController::class, 'destroy'])->middleware('store.token:products.write');
         });
 
         Route::prefix('inventory')->group(function () {
-            Route::get('/stock', [InventoryController::class, 'getStock']);
-            Route::post('/update-stock', [InventoryController::class, 'updateStock']);
-            Route::post('/bulk-update-stock', [InventoryController::class, 'bulkUpdateStock']);
-            Route::get('/movements', [InventoryController::class, 'getMovements']);
+            Route::get('/stock', [InventoryController::class, 'getStock'])->middleware('store.token:inventory.read');
+            Route::post('/update-stock', [InventoryController::class, 'updateStock'])->middleware('store.token:inventory.write');
+            Route::post('/bulk-update-stock', [InventoryController::class, 'bulkUpdateStock'])->middleware('store.token:inventory.write');
+            Route::get('/movements', [InventoryController::class, 'getMovements'])->middleware('store.token:inventory.read');
         });
 
         Route::prefix('orders')->group(function () {
-            Route::get('/', [OrdersController::class, 'index']);
-            Route::post('/', [OrdersController::class, 'store']);
-            Route::get('/external/{externalId}', [OrdersController::class, 'byExternalId']);
-            Route::get('/{id}', [OrdersController::class, 'show']);
-            Route::patch('/{id}/status', [OrdersController::class, 'updateStatus']);
+            Route::get('/', [OrdersController::class, 'index'])->middleware('store.token:orders.read');
+            Route::post('/', [OrdersController::class, 'store'])->middleware('store.token:orders.write');
+            Route::get('/external/{externalId}', [OrdersController::class, 'byExternalId'])->middleware('store.token:orders.read');
+            Route::get('/{id}', [OrdersController::class, 'show'])->middleware('store.token:orders.read');
+            Route::patch('/{id}/status', [OrdersController::class, 'updateStatus'])->middleware('store.token:orders.write');
         });
 
         Route::prefix('customers')->group(function () {
-            Route::get('/', [CustomersController::class, 'index']);
-            Route::post('/', [CustomersController::class, 'store']);
-            Route::get('/email/{email}', [CustomersController::class, 'byEmail']);
-            Route::get('/{id}', [CustomersController::class, 'show']);
-            Route::put('/{id}', [CustomersController::class, 'update']);
-            Route::delete('/{id}', [CustomersController::class, 'destroy']);
+            Route::get('/', [CustomersController::class, 'index'])->middleware('store.token:customers.read');
+            Route::post('/', [CustomersController::class, 'store'])->middleware('store.token:customers.write');
+            Route::get('/email/{email}', [CustomersController::class, 'byEmail'])->middleware('store.token:customers.read');
+            Route::get('/{id}', [CustomersController::class, 'show'])->middleware('store.token:customers.read');
+            Route::put('/{id}', [CustomersController::class, 'update'])->middleware('store.token:customers.write');
+            Route::delete('/{id}', [CustomersController::class, 'destroy'])->middleware('store.token:customers.write');
         });
     });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -654,6 +654,11 @@ Route::middleware('auth')->group(function () {
             ->middleware(['auth', 'can:documents.view']);
     });
 
+    // Attachments
+    Route::get('/attachments/{attachment}/download', \App\Http\Controllers\Attachments\DownloadController::class)
+        ->name('attachments.download')
+        ->middleware(['auth']);
+
     // HELPDESK MODULE
     Route::prefix('app/helpdesk')->name('app.helpdesk.')->group(function () {
         Route::get('/', \App\Livewire\Helpdesk\Index::class)

--- a/tests/Feature/Api/StoreTokenAbilityTest.php
+++ b/tests/Feature/Api/StoreTokenAbilityTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Models\Branch;
+use App\Models\Product;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class StoreTokenAbilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_write_operations_require_explicit_abilities(): void
+    {
+        Storage::fake('private');
+
+        $branch = Branch::factory()->create();
+
+        $store = Store::create([
+            'name' => 'Webhook Store',
+            'type' => Store::TYPE_CUSTOM,
+            'url' => 'https://example.test',
+            'branch_id' => $branch->id,
+            'is_active' => true,
+        ]);
+
+        $token = $store->generateApiToken('readonly', ['products.read']);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token->token,
+        ])->postJson('/api/v1/products', [
+            'name' => 'Blocked Product',
+        ]);
+
+        $response->assertStatus(403);
+        $this->assertDatabaseCount('products', 0);
+    }
+}

--- a/tests/Feature/Components/GlobalSearchAuthorizationTest.php
+++ b/tests/Feature/Components/GlobalSearchAuthorizationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Components;
+
+use App\Livewire\Components\GlobalSearch;
+use App\Models\Branch;
+use App\Models\SearchIndex;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class GlobalSearchAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_results_are_filtered_by_user_permissions(): void
+    {
+        $branch = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $branch->id]);
+
+        Permission::findOrCreate('customers.view');
+        Permission::findOrCreate('sales.view');
+
+        $user->givePermissionTo('customers.view');
+
+        SearchIndex::create([
+            'branch_id' => $branch->id,
+            'searchable_type' => User::class,
+            'searchable_id' => $user->id,
+            'title' => 'Shared Keyword',
+            'content' => 'Shared Keyword content',
+            'module' => 'sales',
+            'icon' => '💵',
+            'url' => '/sales/1',
+            'metadata' => [],
+            'indexed_at' => now(),
+        ]);
+
+        SearchIndex::create([
+            'branch_id' => $branch->id,
+            'searchable_type' => User::class,
+            'searchable_id' => $user->id,
+            'title' => 'Shared Keyword',
+            'content' => 'Another Shared Keyword',
+            'module' => 'customers',
+            'icon' => '👤',
+            'url' => '/customers/1',
+            'metadata' => [],
+            'indexed_at' => now(),
+        ]);
+
+        $component = Livewire::actingAs($user)
+            ->test(GlobalSearch::class)
+            ->set('query', 'Shared')
+            ->call('performSearch');
+
+        $results = $component->get('results');
+
+        $this->assertCount(1, $results);
+        $this->assertSame('customers', $results[0]['module']);
+    }
+
+    public function test_branch_context_is_enforced_when_missing_current_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+
+        $user = User::factory()->create([
+            'branch_id' => $branchA->id,
+        ]);
+
+        Permission::findOrCreate('customers.view');
+        $user->givePermissionTo('customers.view');
+
+        foreach ([$branchA->id, $branchB->id] as $idx => $branchId) {
+            SearchIndex::create([
+                'branch_id' => $branchId,
+                'searchable_type' => User::class,
+                'searchable_id' => $user->id,
+                'title' => 'Alpha Entry',
+                'content' => 'Alpha Entry',
+                'module' => 'customers',
+                'icon' => '👤',
+                'url' => '/customers/'.$idx,
+                'metadata' => [],
+                'indexed_at' => now(),
+            ]);
+        }
+
+        $component = Livewire::actingAs($user)
+            ->test(GlobalSearch::class)
+            ->set('query', 'Alpha')
+            ->call('performSearch');
+
+        $results = $component->get('results');
+
+        $this->assertCount(1, $results);
+        $this->assertSame($branchA->id, $results[0]['branch_id']);
+    }
+}

--- a/tests/Feature/Components/NotesAttachmentsTest.php
+++ b/tests/Feature/Components/NotesAttachmentsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Components;
+
+use App\Livewire\Components\NotesAttachments;
+use App\Models\Attachment;
+use App\Models\Branch;
+use App\Models\Customer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Storage;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class NotesAttachmentsTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithFaker;
+
+    public function test_cross_branch_access_is_forbidden(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+
+        $user = User::factory()->create(['branch_id' => $branchA->id]);
+        Permission::findOrCreate('customers.view');
+        $user->givePermissionTo('customers.view');
+
+        $customerB = Customer::create([
+            'uuid' => (string) Str::uuid(),
+            'code' => 'CUST-B',
+            'name' => 'Branch B Customer',
+            'branch_id' => $branchB->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(NotesAttachments::class, [
+                'modelType' => Customer::class,
+                'modelId' => $customerB->id,
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_disallowed_mime_types_are_rejected_on_upload(): void
+    {
+        $branch = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $branch->id]);
+        Permission::findOrCreate('customers.view');
+        $user->givePermissionTo('customers.view');
+
+        $customer = Customer::create([
+            'uuid' => (string) Str::uuid(),
+            'code' => 'CUST-A',
+            'name' => 'Branch A Customer',
+            'branch_id' => $branch->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(NotesAttachments::class, [
+                'modelType' => Customer::class,
+                'modelId' => $customer->id,
+            ])
+            ->set('newFiles', [
+                UploadedFile::fake()->create('payload.html', 10, 'text/html'),
+            ])
+            ->call('uploadFiles')
+            ->assertHasErrors(['newFiles.0' => 'mimes']);
+    }
+
+    public function test_attachment_download_is_authorized_and_private(): void
+    {
+        Storage::fake('local');
+        config(['filesystems.default' => 'local']);
+
+        $branch = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $branch->id]);
+        Permission::findOrCreate('customers.view');
+        $user->givePermissionTo('customers.view');
+
+        $customer = Customer::create([
+            'uuid' => (string) Str::uuid(),
+            'code' => 'CUST-A',
+            'name' => 'Branch A Customer',
+            'branch_id' => $branch->id,
+        ]);
+
+        $file = UploadedFile::fake()->create('safe.pdf', 20, 'application/pdf');
+
+        Livewire::actingAs($user)
+            ->test(NotesAttachments::class, [
+                'modelType' => Customer::class,
+                'modelId' => $customer->id,
+            ])
+            ->set('newFiles', [$file])
+            ->call('uploadFiles')
+            ->assertHasNoErrors();
+
+        $attachment = Attachment::first();
+        $this->assertNotNull($attachment);
+        Storage::disk('local')->assertExists($attachment->path);
+
+        $this->assertStringContainsString('/attachments/', $attachment->url);
+        $this->assertStringContainsString('/download', $attachment->url);
+
+        $this->actingAs($user)
+            ->get($attachment->url)
+            ->assertOk()
+            ->assertHeader('Content-Disposition', 'inline; filename="safe.pdf"');
+    }
+}


### PR DESCRIPTION
## Summary
- refresh document metadata during version uploads so the stored file extension matches the latest file
- add a regression test confirming new versions update file name, extension, and MIME type metadata
- enforce module permissions and branch context in global search plus add coverage for unauthorized users and branch scoping
- tighten notes/attachments with explicit attachable permission checks, branch validation, private storage, and authorized download links
- require explicit store token abilities on API routes and reject tokens lacking the necessary scopes
- fix regression test to validate attachment download URLs without relying on nonexistent relationships
- force attachments onto the private disk and inject the authorizer via Livewire boot to avoid constructor misuse
- stream safe attachments inline (images/PDF) via the download route and validate the behavior in tests
- avoid forcing attachment downloads to open in a new tab, honoring disposition headers

## Testing
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403 while cloning dependencies)*
- `php artisan test` *(fails: vendor directory missing because dependencies could not be installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945416d856483248d07cce5637d0e88)