### PR TITLE
Fix queue diagnostics to use configured connection

### DIFF
--- a/app/Services/DiagnosticsService.php
+++ b/app/Services/DiagnosticsService.php
@@ -86,11 +86,15 @@ class DiagnosticsService
             // For database driver, check if jobs table exists
             if ($connection === 'database') {
                 $table = Config::get('queue.connections.database.table', 'jobs');
-                $exists = DB::getSchemaBuilder()->hasTable($table);
+                $dbConnection = Config::get('queue.connections.database.connection', Config::get('database.default'));
+                $schema = DB::connection($dbConnection)->getSchemaBuilder();
+
+                $exists = $schema->hasTable($table);
 
                 return [
                     'status' => $exists ? 'ok' : 'warning',
                     'driver' => $connection,
+                    'connection' => $dbConnection,
                     'message' => $exists 
                         ? 'Queue is operational' 
                         : "Queue table '{$table}' does not exist",

--- a/tests/Unit/Services/DiagnosticsServiceTest.php
+++ b/tests/Unit/Services/DiagnosticsServiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\DiagnosticsService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Tests\TestCase;
+
+class DiagnosticsServiceTest extends TestCase
+{
+    public function testDatabaseQueueCheckUsesConfiguredConnection(): void
+    {
+        Config::set('queue.default', 'database');
+        Config::set('queue.connections.database', [
+            'driver' => 'database',
+            'table' => 'jobs',
+            'queue' => 'default',
+            'retry_after' => 90,
+            'after_commit' => false,
+            'connection' => 'queue',
+        ]);
+
+        Config::set('database.default', 'primary');
+        Config::set('database.connections.primary', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+        Config::set('database.connections.queue', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        DB::setDefaultConnection('primary');
+
+        Schema::connection('queue')->create('jobs', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+
+        $result = app(DiagnosticsService::class)->checkQueue();
+
+        $this->assertSame('ok', $result['status']);
+        $this->assertSame('database', $result['driver']);
+        $this->assertSame('queue', $result['connection']);
+        $this->assertStringContainsString('Queue is operational', $result['message']);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure DiagnosticsService checks the configured queue database connection when using the database driver
- add unit coverage proving the queue diagnostics uses the configured connection rather than the default database

## Testing
- Unable to run `phpunit --filter DiagnosticsServiceTest` (phpunit executable not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694681e55b4c8324b68017b491cf46df)