### PR TITLE
Add authenticated fallback URLs for media stored off public disk

### DIFF
--- a/app/Http/Controllers/Admin/MediaDownloadController.php
+++ b/app/Http/Controllers/Admin/MediaDownloadController.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Media;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class MediaDownloadController extends Controller
+{
+    public function __invoke(Media $media, Request $request): StreamedResponse
+    {
+        $user = $request->user();
+
+        abort_unless($user?->can('media.view'), 403, __('You do not have permission to view media files.'));
+
+        if (!$user->can('media.view-others') && $media->user_id !== $user->id) {
+            abort(403, __('You do not have permission to access this file.'));
+        }
+
+        $serveThumbnail = $request->boolean('thumbnail');
+        $path = $serveThumbnail && $media->thumbnail_path ? $media->thumbnail_path : $media->file_path;
+
+        $disk = Storage::disk($media->disk);
+
+        abort_unless($disk->exists($path), 404, __('File not found.'));
+
+        $filename = $serveThumbnail
+            ? basename($path)
+            : ($media->original_name ?: $media->name);
+
+        $headers = [
+            'Content-Type' => $media->mime_type ?? 'application/octet-stream',
+        ];
+
+        return $disk->response($path, $filename, $headers);
+    }
+}

--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -50,7 +50,7 @@ class MediaLibrary extends Component
         }
 
         $optimizationService = app(ImageOptimizationService::class);
-        $disk = 'local';
+        $disk = config('filesystems.media_disk', 'public');
 
         foreach ($this->files as $file) {
             $this->guardAgainstHtmlPayload($file);

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -16,6 +16,7 @@ return [
     'default' => env('FILESYSTEM_DISK', env('APP_ENV') === 'production' ? 'public' : 'local'),
 
     'document_disk' => env('DOCUMENTS_DISK', 'local'),
+    'media_disk' => env('MEDIA_DISK', 'public'),
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/web.php
+++ b/routes/web.php
@@ -913,6 +913,9 @@ Route::get('/attachments/{attachment}/download', \App\Http\Controllers\Attachmen
         Route::get('/media', \App\Livewire\Admin\MediaLibrary::class)
             ->name('media.index')
             ->middleware('can:media.view');
+        Route::get('/media/{media}/download', \App\Http\Controllers\Admin\MediaDownloadController::class)
+            ->name('media.download')
+            ->middleware(['auth', 'can:media.view']);
 
         // Audit Logs
         Route::get('/logs/audit', AuditLogPage::class)

--- a/tests/Feature/Admin/MediaDownloadControllerTest.php
+++ b/tests/Feature/Admin/MediaDownloadControllerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Admin;
+
+use App\Models\Media;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class MediaDownloadControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        Permission::create(['name' => 'media.view', 'guard_name' => 'web']);
+        Permission::create(['name' => 'media.view-others', 'guard_name' => 'web']);
+    }
+
+    public function test_user_can_stream_own_media_from_local_disk(): void
+    {
+        Storage::fake('local');
+
+        $user = User::factory()->create();
+        $user->givePermissionTo(['media.view', 'media.view-others']);
+
+        $path = 'media/test-file.txt';
+        Storage::disk('local')->put($path, 'file contents');
+
+        $media = Media::create([
+            'name' => 'Test File',
+            'original_name' => 'test-file.txt',
+            'file_path' => $path,
+            'mime_type' => 'text/plain',
+            'extension' => 'txt',
+            'size' => 14,
+            'disk' => 'local',
+            'collection' => 'general',
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->get(route('app.media.download', $media));
+
+        $response->assertOk();
+        $response->assertSee('file contents');
+        $response->assertHeader('content-type', 'text/plain');
+    }
+
+    public function test_user_without_view_others_permission_cannot_access_foreign_media(): void
+    {
+        Storage::fake('local');
+
+        $owner = User::factory()->create();
+        $owner->givePermissionTo(['media.view', 'media.view-others']);
+
+        $viewer = User::factory()->create();
+        $viewer->givePermissionTo(['media.view']);
+
+        $path = 'media/secret.txt';
+        Storage::disk('local')->put($path, 'top secret');
+
+        $media = Media::create([
+            'name' => 'Secret',
+            'original_name' => 'secret.txt',
+            'file_path' => $path,
+            'mime_type' => 'text/plain',
+            'extension' => 'txt',
+            'size' => 10,
+            'disk' => 'local',
+            'collection' => 'general',
+            'user_id' => $owner->id,
+        ]);
+
+        $this->actingAs($viewer)
+            ->get(route('app.media.download', $media))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- make media uploads respect a configurable media disk
- add an authenticated download endpoint and model URL fallbacks so media on non-public disks can still be viewed
- cover media streaming and ownership enforcement with new feature tests

## Testing
- php artisan test tests/Feature/Admin/MediaDownloadControllerTest.php *(fails: vendor/autoload.php missing because Composer install could not complete without GitHub access token)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69468307de308324b494042628a2b687)