### PR TITLE
Handle document downloads via storage drivers

### DIFF
--- a/app/Http/Controllers/Documents/DownloadController.php
+++ b/app/Http/Controllers/Documents/DownloadController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\Document;
 use App\Services\DocumentService;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class DownloadController extends Controller
@@ -24,28 +23,7 @@ class DownloadController extends Controller
         }
 
         $inline = request()->boolean('inline');
-        
-        $disk = $this->documentService->documentsDisk();
-        $resolvedDisk = Storage::disk($disk)->exists($document->file_path)
-            ? $disk
-            : 'public';
 
-        // Verify file exists on the resolved disk
-        abort_unless(Storage::disk($resolvedDisk)->exists($document->file_path), 404, 'File not found');
-        
-        // Validate access and log download (throws 403 if unauthorized)
-        $this->documentService->downloadDocument($document, Auth::user());
-
-        $headers = ['Content-Type' => $document->mime_type];
-
-        if ($inline) {
-            return Storage::disk($resolvedDisk)->response(
-                $document->file_path,
-                $document->file_name,
-                $headers
-            );
-        }
-
-        return Storage::disk($resolvedDisk)->download($document->file_path, $document->file_name, $headers);
+        return $this->documentService->downloadDocument($document, Auth::user(), $inline);
     }
 }

--- a/app/Livewire/Documents/Show.php
+++ b/app/Livewire/Documents/Show.php
@@ -53,9 +53,11 @@ class Show extends Component
     {
         $this->authorize('documents.download');
 
-        $path = $this->documentService->downloadDocument($this->document, auth()->user());
-
-        return response()->download($path, $this->document->file_name);
+        return $this->documentService->downloadDocument(
+            $this->document,
+            auth()->user(),
+            request()->boolean('inline', false)
+        );
     }
 
     public function shareDocument(): void


### PR DESCRIPTION
## Summary
- stream document downloads directly through the DocumentService to honor storage drivers and enforce file existence checks
- simplify the documents download controller to reuse the service response while keeping branch validation
- return Livewire document downloads via the storage-backed response, including optional inline handling

## Testing
- php -l app/Services/DocumentService.php
- php -l app/Livewire/Documents/Show.php
- php -l app/Http/Controllers/Documents/DownloadController.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69468519bcb483249dbeb9fbc6d31e0d)