### PR TITLE
Enforce branch checks for document version uploads

### DIFF
--- a/app/Livewire/Documents/Versions.php
+++ b/app/Livewire/Documents/Versions.php
@@ -33,6 +33,11 @@ class Versions extends Component
         $this->authorize('documents.versions.manage');
         $this->document = $document->load(['versions.uploader']);
 
+        $user = auth()->user();
+        if ($user && $user->branch_id && $document->branch_id && $user->branch_id !== $document->branch_id) {
+            abort(403, 'You cannot manage versions for documents from other branches.');
+        }
+
         // Check if user can access this document
         if (!$document->canBeAccessedBy(auth()->user())) {
             abort(403, 'You do not have permission to manage versions for this document');

--- a/app/Services/DocumentService.php
+++ b/app/Services/DocumentService.php
@@ -105,6 +105,11 @@ class DocumentService
     {
         $this->validateFile($file);
 
+        $user = auth()->user();
+        if ($user && $user->branch_id && $document->branch_id && $user->branch_id !== $document->branch_id) {
+            throw new AuthorizationException('You cannot upload versions for documents outside your branch.');
+        }
+
         return DB::transaction(function () use ($document, $file, $changeNotes) {
             // Store the file on the configured private disk
             $disk = $this->documentsDisk;


### PR DESCRIPTION
## Summary
- enforce branch-based authorization when mounting the document versions component and within the service upload flow
- update document version upload tests to support configurable branches and assert cross-branch attempts are forbidden

## Testing
- php artisan test --filter=DocumentVersionUploadTest *(fails: vendor/autoload.php missing because composer install cannot download dependencies due to proxy/GitHub 403 errors)*
- composer install --no-interaction *(fails: CONNECT tunnel 403 when downloading packages from GitHub, preventing vendor setup)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694686bffd008324898b0c365fa496f0)