### PR TITLE
Handle nullable passwords on admin user updates

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -58,8 +58,12 @@ class UserController extends Controller
             'is_active' => ['boolean'],
             'roles' => ['sometimes', 'array'],
         ]);
+
         if (array_key_exists('password', $data)) {
-            $user->password = Hash::make($data['password']);
+            if ($data['password'] !== null) {
+                $user->password = Hash::make($data['password']);
+            }
+
             unset($data['password']);
         }
         $user->fill($data);


### PR DESCRIPTION
## Summary
- avoid hashing null passwords during admin user updates to prevent unintentionally resetting credentials
- keep remaining update payload handling unchanged while still allowing optional password changes

## Testing
- php -l app/Http/Controllers/Admin/UserController.php
- composer install (fails: unable to reach api.github.com through proxy to install vendor dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694686b8baf083248acf753e7abc3dc8)