### PR TITLE
Ensure branch scope loads user branches

### DIFF
--- a/app/Models/Traits/HasBranch.php
+++ b/app/Models/Traits/HasBranch.php
@@ -43,7 +43,11 @@ trait HasBranch
 
         $branchIds = [];
 
-        if (method_exists($user, 'branches') && $user->relationLoaded('branches')) {
+        if (method_exists($user, 'branches')) {
+            if (! $user->relationLoaded('branches')) {
+                $user->load('branches');
+            }
+
             $branchIds = $user->branches->pluck('id')->toArray();
         }
 

--- a/tests/Unit/HasBranchScopeTest.php
+++ b/tests/Unit/HasBranchScopeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\Branch;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class HasBranchScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_for_user_branches_loads_branch_relation_when_missing(): void
+    {
+        $primaryBranch = Branch::factory()->create();
+        $secondaryBranch = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $primaryBranch->id]);
+
+        // Attach an additional branch without touching the relation to mimic lazy loading
+        $user->branches()->attach($secondaryBranch->id);
+        $this->assertFalse($user->relationLoaded('branches'));
+
+        $projectInSecondary = Project::create([
+            'branch_id' => $secondaryBranch->id,
+            'code' => 'PRJ-' . Str::random(5),
+            'name' => 'Scoped Project',
+            'description' => 'Ensures branch scope uses attached branches.',
+            'status' => 'planning',
+            'start_date' => now()->format('Y-m-d'),
+            'end_date' => now()->addWeek()->format('Y-m-d'),
+        ]);
+
+        $scopedBranchIds = Project::query()
+            ->forUserBranches($user)
+            ->pluck('branch_id')
+            ->all();
+
+        $this->assertContains($projectInSecondary->branch_id, $scopedBranchIds);
+        $this->assertContains($primaryBranch->id, $scopedBranchIds);
+    }
+}


### PR DESCRIPTION
## Summary
- load the user's branches relationship inside the forUserBranches scope to respect attached branches even when not eager loaded
- add a unit test covering access to projects in secondary branches when the relation has not been preloaded

## Testing
- php artisan test --filter=HasBranchScopeTest *(fails: composer install blocked by network restrictions)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694689cab7e08332872f4af809859425)