### PR TITLE
Ensure helpdesk branch isolation and secure document downloads

### DIFF
--- a/app/Livewire/Helpdesk/Tickets/Form.php
+++ b/app/Livewire/Helpdesk/Tickets/Form.php
@@ -56,6 +56,10 @@ class Form extends Component
         }
 
         if ($ticket && $ticket->exists) {
+            if (! $user->can('update', $ticket)) {
+                abort(403);
+            }
+
             $this->isEditing = true;
             $this->ticket = $ticket;
             $this->fill([
@@ -78,6 +82,9 @@ class Form extends Component
         $this->validate();
 
         $user = Auth::user();
+        if ($this->isEditing && $this->ticket && ! $user?->can('update', $this->ticket)) {
+            abort(403);
+        }
 
         $data = [
             'subject' => $this->subject,
@@ -90,7 +97,7 @@ class Form extends Component
             'sla_policy_id' => $this->sla_policy_id,
             'due_date' => $this->due_date,
             'tags' => $this->tags,
-            'branch_id' => $user->branch_id,
+            'branch_id' => $this->ticket?->branch_id ?? $user->branch_id,
         ];
 
         if ($this->isEditing) {

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -141,6 +141,14 @@ class Document extends Model
             return true;
         }
 
+        if (
+            $this->branch_id
+            && $user->branch_id
+            && $this->branch_id !== $user->branch_id
+        ) {
+            return false;
+        }
+
         // Owner can always access
         if ($this->uploaded_by === $user->id) {
             return true;

--- a/app/Policies/TicketPolicy.php
+++ b/app/Policies/TicketPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Ticket;
+use App\Models\User;
+
+class TicketPolicy
+{
+    public function update(User $user, Ticket $ticket): bool
+    {
+        if (method_exists($user, 'hasRole') && $user->hasRole('Super Admin')) {
+            return true;
+        }
+
+        if (! $user->can('helpdesk.manage')) {
+            return false;
+        }
+
+        if ($user->branch_id && $ticket->branch_id && $user->branch_id !== $ticket->branch_id) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function delete(User $user, Ticket $ticket): bool
+    {
+        return $this->update($user, $ticket);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -16,6 +16,7 @@ use App\Models\RentalContract;
 use App\Models\RentalInvoice;
 use App\Models\RentalUnit;
 use App\Models\Sale;
+use App\Models\Ticket;
 use App\Models\Tenant;
 use App\Models\Vehicle;
 use App\Models\WorkCenter;
@@ -26,6 +27,7 @@ use App\Policies\NotificationPolicy;
 use App\Policies\ProductPolicy;
 use App\Policies\PurchasePolicy;
 use App\Policies\RentalPolicy;
+use App\Policies\TicketPolicy;
 use App\Policies\SalePolicy;
 use App\Policies\VehiclePolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -43,6 +45,7 @@ class AuthServiceProvider extends ServiceProvider
         Sale::class => SalePolicy::class,
         Vehicle::class => VehiclePolicy::class,
         Notification::class => NotificationPolicy::class,
+        Ticket::class => TicketPolicy::class,
 
         // Rental domain mapped to a generic policy handling multiple models
         RentalContract::class => RentalPolicy::class,

--- a/app/Services/DocumentService.php
+++ b/app/Services/DocumentService.php
@@ -327,11 +327,13 @@ class DocumentService
     {
         $primaryDisk = $this->documentsDisk;
 
-        if (Storage::disk($primaryDisk)->exists($path)) {
-            return $primaryDisk;
-        }
+        abort_unless(
+            Storage::disk($primaryDisk)->exists($path),
+            404,
+            'File not found'
+        );
 
-        return 'public';
+        return $primaryDisk;
     }
 
     private function validateFile(UploadedFile $file): void

--- a/tests/Feature/Documents/DocumentDownloadFallbackTest.php
+++ b/tests/Feature/Documents/DocumentDownloadFallbackTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Documents;
+
+use App\Models\Branch;
+use App\Models\Document;
+use App\Models\User;
+use App\Services\DocumentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class DocumentDownloadFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_missing_private_file_returns_not_found_instead_of_public_fallback(): void
+    {
+        config(['filesystems.document_disk' => 'local']);
+        Storage::fake('local');
+        Storage::fake('public');
+
+        $branch = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $branch->id]);
+
+        Permission::findOrCreate('documents.download', 'web');
+        $user->givePermissionTo('documents.download');
+
+        $document = Document::create([
+            'title' => 'Secure Document',
+            'code' => 'DOC-SEC',
+            'file_name' => 'secure.pdf',
+            'file_path' => 'documents/secure.pdf',
+            'file_size' => 100,
+            'file_type' => 'pdf',
+            'mime_type' => 'application/pdf',
+            'status' => 'published',
+            'branch_id' => $branch->id,
+            'uploaded_by' => $user->id,
+            'is_public' => false,
+            'access_level' => 'private',
+        ]);
+
+        Storage::disk('public')->put($document->file_path, 'public copy');
+
+        $this->actingAs($user);
+
+        $this->expectException(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+        $this->expectExceptionMessage('File not found');
+
+        app(DocumentService::class)->downloadDocument($document, $user);
+    }
+}

--- a/tests/Feature/Helpdesk/Tickets/TicketAssignmentBranchTest.php
+++ b/tests/Feature/Helpdesk/Tickets/TicketAssignmentBranchTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Helpdesk\Tickets;
+
+use App\Livewire\Helpdesk\TicketDetail;
+use App\Models\Branch;
+use App\Models\Ticket;
+use App\Models\TicketCategory;
+use App\Models\TicketPriority;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TicketAssignmentBranchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::define('helpdesk.view', fn () => true);
+        Gate::define('helpdesk.assign', fn () => true);
+    }
+
+    protected function createCategory(): TicketCategory
+    {
+        return TicketCategory::create([
+            'name' => 'Support',
+            'slug' => 'support',
+            'is_active' => true,
+        ]);
+    }
+
+    protected function createPriority(): TicketPriority
+    {
+        return TicketPriority::create([
+            'name' => 'Medium',
+            'slug' => 'medium',
+            'level' => 2,
+            'color' => '#FFA500',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_assigning_ticket_to_other_branch_user_is_rejected(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+
+        $agentA = User::factory()->create(['branch_id' => $branchA->id]);
+        $agentB = User::factory()->create(['branch_id' => $branchB->id]);
+
+        $ticket = Ticket::create([
+            'ticket_number' => 'TKT-910001',
+            'subject' => 'Assignment test',
+            'description' => 'Test',
+            'status' => 'open',
+            'priority_id' => $this->createPriority()->id,
+            'category_id' => $this->createCategory()->id,
+            'branch_id' => $branchA->id,
+        ]);
+
+        Livewire::actingAs($agentA)
+            ->test(TicketDetail::class, ['ticket' => $ticket])
+            ->set('assignToUser', $agentB->id)
+            ->call('assignTicket')
+            ->assertHasErrors(['assignToUser' => 'exists']);
+
+        $this->assertNull($ticket->fresh()->assigned_to);
+    }
+}

--- a/tests/Feature/Helpdesk/Tickets/TicketFormBranchAuthorizationTest.php
+++ b/tests/Feature/Helpdesk/Tickets/TicketFormBranchAuthorizationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Helpdesk\Tickets;
+
+use App\Livewire\Helpdesk\Tickets\Form;
+use App\Models\Branch;
+use App\Models\Ticket;
+use App\Models\TicketCategory;
+use App\Models\TicketPriority;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+class TicketFormBranchAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::define('helpdesk.manage', fn () => true);
+    }
+
+    protected function createCategory(): TicketCategory
+    {
+        return TicketCategory::create([
+            'name' => 'General',
+            'slug' => 'general',
+            'is_active' => true,
+        ]);
+    }
+
+    protected function createPriority(): TicketPriority
+    {
+        return TicketPriority::create([
+            'name' => 'Medium',
+            'slug' => 'medium',
+            'level' => 2,
+            'color' => '#FFA500',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_manager_cannot_edit_ticket_from_other_branch(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $branchA->id]);
+        $ticket = Ticket::create([
+            'ticket_number' => 'TKT-900001',
+            'subject' => 'Branch B Ticket',
+            'description' => 'Test',
+            'status' => 'new',
+            'priority_id' => $this->createPriority()->id,
+            'category_id' => $this->createCategory()->id,
+            'branch_id' => $branchB->id,
+        ]);
+
+        $this->expectException(HttpException::class);
+        Livewire::actingAs($user)
+            ->test(Form::class, ['ticket' => $ticket]);
+    }
+
+    public function test_branch_remains_unchanged_when_ticket_is_updated(): void
+    {
+        $branch = Branch::factory()->create();
+        $user = User::factory()->create(['branch_id' => $branch->id]);
+        $ticket = Ticket::create([
+            'ticket_number' => 'TKT-900002',
+            'subject' => 'Original',
+            'description' => 'Test',
+            'status' => 'new',
+            'priority_id' => $this->createPriority()->id,
+            'category_id' => $this->createCategory()->id,
+            'branch_id' => $branch->id,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(Form::class, ['ticket' => $ticket])
+            ->set('subject', 'Updated Subject')
+            ->set('status', 'open')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertSame($branch->id, $ticket->fresh()->branch_id);
+    }
+}

--- a/tests/Unit/DocumentBranchAccessTest.php
+++ b/tests/Unit/DocumentBranchAccessTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use App\Models\Branch;
+use App\Models\Document;
+use App\Models\DocumentShare;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DocumentBranchAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_shared_user_from_other_branch_cannot_access_private_document(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+
+        $owner = User::factory()->create(['branch_id' => $branchA->id]);
+        $otherBranchUser = User::factory()->create(['branch_id' => $branchB->id]);
+
+        $document = Document::create([
+            'title' => 'Private Doc',
+            'code' => 'DOC-PRIVATE',
+            'file_name' => 'private.pdf',
+            'file_path' => 'documents/private.pdf',
+            'file_size' => 128,
+            'file_type' => 'pdf',
+            'mime_type' => 'application/pdf',
+            'status' => 'published',
+            'branch_id' => $branchA->id,
+            'uploaded_by' => $owner->id,
+            'is_public' => false,
+            'access_level' => 'private',
+        ]);
+
+        DocumentShare::create([
+            'document_id' => $document->id,
+            'shared_with_user_id' => $otherBranchUser->id,
+            'shared_by' => $owner->id,
+            'permission' => 'view',
+        ]);
+
+        $this->assertFalse($document->canBeAccessedBy($otherBranchUser));
+    }
+
+    public function test_public_document_can_be_accessed_across_branches(): void
+    {
+        $branchA = Branch::factory()->create();
+        $branchB = Branch::factory()->create();
+
+        $owner = User::factory()->create(['branch_id' => $branchA->id]);
+        $otherBranchUser = User::factory()->create(['branch_id' => $branchB->id]);
+
+        $document = Document::create([
+            'title' => 'Public Doc',
+            'code' => 'DOC-PUBLIC',
+            'file_name' => 'public.pdf',
+            'file_path' => 'documents/public.pdf',
+            'file_size' => 256,
+            'file_type' => 'pdf',
+            'mime_type' => 'application/pdf',
+            'status' => 'published',
+            'branch_id' => $branchA->id,
+            'uploaded_by' => $owner->id,
+            'is_public' => true,
+            'access_level' => 'public',
+        ]);
+
+        $this->assertTrue($document->canBeAccessedBy($otherBranchUser));
+    }
+}


### PR DESCRIPTION
## Summary
- enforce branch-aware authorization for helpdesk ticket editing and assignment, including a ticket policy
- prevent document downloads from falling back to the public disk and enforce branch-aware access checks
- add regression tests covering ticket branch scoping, assignment restrictions, and document access safeguards

## Testing
- Not run (phpunit unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6947e40560288332bf37abcb7a6dc036)