### PR TITLE
Align document activity logging with schema

### DIFF
--- a/app/Models/DocumentActivity.php
+++ b/app/Models/DocumentActivity.php
@@ -20,14 +20,15 @@ class DocumentActivity extends Model
         'document_id',
         'user_id',
         'action',
-        'details',
+        'description',
+        'metadata',
         'ip_address',
         'user_agent',
         'created_at',
     ];
 
     protected $casts = [
-        'details' => 'array',
+        'metadata' => 'array',
     ];
 
     // Relationships
@@ -59,12 +60,13 @@ class DocumentActivity extends Model
             'created' => __('Created'),
             'viewed' => __('Viewed'),
             'downloaded' => __('Downloaded'),
-            'updated' => __('Updated'),
+            'edited' => __('Edited'),
             'deleted' => __('Deleted'),
             'shared' => __('Shared'),
             'unshared' => __('Unshared'),
+            'restored' => __('Restored'),
             'version_created' => __('New version created'),
-            default => __(ucfirst($this->action)),
+            default => __(ucwords(str_replace('_', ' ', $this->action))),
         };
     }
 }

--- a/app/Services/DocumentService.php
+++ b/app/Services/DocumentService.php
@@ -197,7 +197,7 @@ class DocumentService
             }
 
             // Log activity
-            $document->logActivity('updated', auth()->user());
+            $document->logActivity('edited', auth()->user());
 
             return $document->fresh();
         });


### PR DESCRIPTION
## Summary
- align `DocumentActivity` with the `metadata` column and refreshed action labels
- capture IP/user agent data while logging activities and normalize the `updated` action to the enum-compliant value
- ensure document updates log the `edited` action to match the database schema
- allow document activity records to persist optional descriptions while keeping metadata JSON intact

## Testing
- php -l app/Models/Document.php app/Models/DocumentActivity.php app/Services/DocumentService.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694869cd834c8324869302344291b9b6)