### PR TITLE
Align document sharing permissions with schema

### DIFF
--- a/app/Http/Requests/DocumentShareRequest.php
+++ b/app/Http/Requests/DocumentShareRequest.php
@@ -16,8 +16,8 @@ class DocumentShareRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id' => ['required', 'exists:users,id'],
-            'permission' => ['required', 'in:view,edit,full'],
+            'shared_with_user_id' => ['required', 'exists:users,id'],
+            'permission' => ['required', 'in:view,download,edit,manage'],
             'expires_at' => ['nullable', 'date', 'after:now'],
         ];
     }
@@ -25,8 +25,8 @@ class DocumentShareRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'user_id.required' => __('Please select a user to share with'),
-            'user_id.exists' => __('Selected user does not exist'),
+            'shared_with_user_id.required' => __('Please select a user to share with'),
+            'shared_with_user_id.exists' => __('Selected user does not exist'),
             'permission.required' => __('Please select a permission level'),
             'permission.in' => __('Invalid permission level'),
             'expires_at.after' => __('Expiration date must be in the future'),

--- a/app/Livewire/Documents/Show.php
+++ b/app/Livewire/Documents/Show.php
@@ -66,7 +66,7 @@ class Show extends Component
 
         $this->validate([
             'shareUserId' => 'required|exists:users,id',
-            'sharePermission' => 'required|in:view,edit,full',
+            'sharePermission' => 'required|in:view,download,edit,manage',
             'shareExpiresAt' => 'nullable|date|after:now',
         ]);
 

--- a/app/Models/DocumentShare.php
+++ b/app/Models/DocumentShare.php
@@ -14,6 +14,7 @@ class DocumentShare extends Model
 
     protected $fillable = [
         'document_id',
+        'user_id',
         'shared_with_user_id',
         'shared_with_role',
         'shared_by',
@@ -77,16 +78,16 @@ class DocumentShare extends Model
 
     public function canView(): bool
     {
-        return in_array($this->permission, ['view', 'edit', 'full']);
+        return in_array($this->permission, ['view', 'download', 'edit', 'manage']);
     }
 
     public function canEdit(): bool
     {
-        return in_array($this->permission, ['edit', 'full']);
+        return in_array($this->permission, ['edit', 'manage']);
     }
 
     public function canDelete(): bool
     {
-        return $this->permission === 'full';
+        return $this->permission === 'manage';
     }
 }

--- a/app/Services/DocumentService.php
+++ b/app/Services/DocumentService.php
@@ -208,6 +208,12 @@ class DocumentService
      */
     public function shareDocument(Document $document, int $userId, string $permission = 'view', ?\DateTime $expiresAt = null): void
     {
+        $allowedPermissions = ['view', 'download', 'edit', 'manage'];
+
+        if (!in_array($permission, $allowedPermissions, true)) {
+            throw new AuthorizationException('Invalid share permission supplied.');
+        }
+
         $this->ensureCanManageShares($document);
         $targetUser = User::findOrFail($userId);
 
@@ -223,6 +229,7 @@ class DocumentService
             $document->shares()->updateOrCreate(
                 ['shared_with_user_id' => $userId],
                 [
+                    'user_id' => $userId,
                     'shared_by' => auth()->id(),
                     'permission' => $permission,
                     'expires_at' => $expiresAt,

--- a/resources/views/livewire/documents/show.blade.php
+++ b/resources/views/livewire/documents/show.blade.php
@@ -142,8 +142,9 @@
                             </select>
                             <select wire:model="sharePermission" class="erp-input w-full">
                                 <option value="view">{{ __('View Only') }}</option>
+                                <option value="download">{{ __('Can Download') }}</option>
                                 <option value="edit">{{ __('Can Edit') }}</option>
-                                <option value="full">{{ __('Full Access') }}</option>
+                                <option value="manage">{{ __('Full Access') }}</option>
                             </select>
                             <input type="datetime-local" wire:model="shareExpiresAt" class="erp-input w-full" placeholder="{{ __('Expires At (Optional)') }}">
                             <button wire:click="shareDocument" class="erp-btn erp-btn-primary w-full">{{ __('Share') }}</button>
@@ -159,7 +160,7 @@
                                                 <p class="text-sm text-slate-900">{{ $share->user->name }}</p>
                                                 <p class="text-xs text-slate-500">{{ ucfirst($share->permission) }}</p>
                                             </div>
-                                            <button wire:click="unshare({{ $share->user_id }})" class="text-xs text-red-600 hover:text-red-900">{{ __('Revoke') }}</button>
+                                            <button wire:click="unshare({{ $share->shared_with_user_id }})" class="text-xs text-red-600 hover:text-red-900">{{ __('Revoke') }}</button>
                                         </div>
                                     @endforeach
                                 </div>


### PR DESCRIPTION
## Summary
- align document share permission values with the database enum and sync the stored shared user id
- enforce allowed permission options inside the document sharing service and validation request
- update the document share UI to use the correct user reference and permission labels

## Testing
- php -l app/Models/DocumentShare.php
- php -l app/Services/DocumentService.php
- php -l app/Http/Requests/DocumentShareRequest.php
- php -l app/Livewire/Documents/Show.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69487215201c8324a4897610ecc73e2e)