### PR TITLE
Add missing rejection reason column to project expenses

### DIFF
--- a/database/migrations/2025_12_31_160500_add_rejection_reason_to_project_expenses.php
+++ b/database/migrations/2025_12_31_160500_add_rejection_reason_to_project_expenses.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (Schema::hasTable('project_expenses') && ! Schema::hasColumn('project_expenses', 'rejection_reason')) {
+            Schema::table('project_expenses', function (Blueprint $table) {
+                $table->text('rejection_reason')->nullable()->after('approved_date');
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (Schema::hasTable('project_expenses') && Schema::hasColumn('project_expenses', 'rejection_reason')) {
+            Schema::table('project_expenses', function (Blueprint $table) {
+                $table->dropColumn('rejection_reason');
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration to introduce the missing `rejection_reason` field on the `project_expenses` table
- ensure the new column is added safely only when absent and dropped on rollback

## Testing
- Not run (vendor directory missing in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69487349b96c832498d5e90ea8a19ece)