### PR TITLE
Fix store order foreign key ordering in sales migration

### DIFF
--- a/database/migrations/2025_11_15_000012_create_sales_and_items_tables.php
+++ b/database/migrations/2025_11_15_000012_create_sales_and_items_tables.php
@@ -43,7 +43,6 @@ return new class extends Migration
             $table->date('delivery_date')->nullable()->comment('Delivery date');
             $table->date('expected_delivery_date')->nullable()->comment('Expected delivery date');
             $table->date('actual_delivery_date')->nullable()->comment('Actual delivery date');
-            $table->unsignedBigInteger('store_order_id')->nullable()->comment('Linked store order');
             $table->string('reference_no')->nullable()->comment('reference_no');
             $table->timestamp('posted_at')->nullable()->comment('posted_at');
             $table->string('sales_person')->nullable()->comment('Sales person name or user ID');
@@ -62,14 +61,12 @@ return new class extends Migration
             $table->index('payment_status');
             $table->index('payment_due_date');
             $table->index(['branch_id', 'payment_status'], 'sales_branch_payment_idx');
-            $table->index('store_order_id');
 
             $table->foreign('branch_id')->references('id')->on('branches')->onDelete('cascade');
             $table->foreign('warehouse_id')->references('id')->on('warehouses')->onDelete('restrict');
             $table->foreign('customer_id')->references('id')->on('customers')->onDelete('set null');
             $table->foreign('created_by')->references('id')->on('users')->onDelete('set null');
             $table->foreign('updated_by')->references('id')->on('users')->onDelete('set null');
-            $table->foreign('store_order_id')->references('id')->on('store_orders')->onDelete('set null');
 
             $table->index(['branch_id', 'customer_id', 'status'], 'sales_br_cust_stat_idx');
             $table->index('branch_id');


### PR DESCRIPTION
## Summary
- remove the premature store_order_id column and foreign key from the initial sales migration
- rely on later migrations to add the column and constraint after the store_orders table exists

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69487e4477648324832b2b1ee5faad65)