### PR TITLE
Harden document uploads and media deletion rules

### DIFF
--- a/app/Livewire/Admin/MediaLibrary.php
+++ b/app/Livewire/Admin/MediaLibrary.php
@@ -121,7 +121,7 @@ class MediaLibrary extends Component
             ->findOrFail($id);
 
         // Check permissions
-        $canDelete = ($user->can('media.manage') && $canBypassBranch) ||
+        $canDelete = $user->can('media.manage') ||
                      ($user->can('media.delete') && $media->user_id === $user->id);
 
         if (!$canDelete) {

--- a/app/Livewire/Documents/Versions.php
+++ b/app/Livewire/Documents/Versions.php
@@ -46,8 +46,11 @@ class Versions extends Component
 
     public function uploadVersion(): void
     {
+        $allowedExtensions = implode(',', DocumentService::ALLOWED_EXTENSIONS);
+        $allowedMimeTypes = implode(',', DocumentService::ALLOWED_MIME_TYPES);
+
         $this->validate([
-            'file' => 'required|file|max:51200|mimes:pdf,doc,docx,xls,xlsx,ppt,pptx,png,jpg,jpeg,gif,csv,txt',
+            'file' => "required|file|max:51200|mimes:{$allowedExtensions}|mimetypes:{$allowedMimeTypes}",
             'changeNotes' => 'nullable|string',
         ]);
 


### PR DESCRIPTION
## Summary
- allow media managers to delete items within their branch without requiring global access
- strengthen document upload/version flows by re-validating stored MIME types
- align Livewire validation with shared document MIME/type whitelists

## Testing
- php -l app/Livewire/Admin/MediaLibrary.php
- php -l app/Livewire/Documents/Versions.php
- php -l app/Services/DocumentService.php


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a6181d8cc8332abeb3f0171317c80)