### PR TITLE
Fix warehouse adjustment stock movements

### DIFF
--- a/app/Livewire/Warehouse/Adjustments/Index.php
+++ b/app/Livewire/Warehouse/Adjustments/Index.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\Warehouse\Adjustments;
 
 use App\Models\Adjustment;
+use App\Models\AdjustmentItem;
+use App\Models\StockMovement;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Layout;
 use Livewire\Attributes\Url;
@@ -54,6 +56,15 @@ class Index extends Component
         $user = auth()->user();
         if ($user->branch_id && $adjustment->branch_id !== $user->branch_id) {
             abort(403, 'Unauthorized access to this branch data');
+        }
+
+        $itemIds = $adjustment->items()->pluck('id');
+        if ($itemIds->isNotEmpty()) {
+            StockMovement::where('reference_type', AdjustmentItem::class)
+                ->whereIn('reference_id', $itemIds)
+                ->delete();
+
+            $adjustment->items()->delete();
         }
 
         $adjustment->delete();

--- a/app/Services/InventoryService.php
+++ b/app/Services/InventoryService.php
@@ -169,30 +169,32 @@ class InventoryService implements InventoryServiceInterface
         return $this->handleServiceOperation(
             callback: function () use ($data) {
                 return \Illuminate\Support\Facades\DB::transaction(function () use ($data) {
-                $payload = [
-                    'product_id' => $data['product_id'] ?? null,
-                    'warehouse_id' => $data['warehouse_id'] ?? null,
-                    'branch_id' => $data['branch_id'] ?? $this->currentBranchId(),
-                    'direction' => $data['direction'] ?? $data['type'] ?? null,
-                    'qty' => $data['qty'] ?? $data['quantity'] ?? null,
-                    'reason' => $data['reason'] ?? null,
-                    'meta' => $data['meta'] ?? [],
-                ];
+                    $payload = [
+                        'product_id' => $data['product_id'] ?? null,
+                        'warehouse_id' => $data['warehouse_id'] ?? null,
+                        'branch_id' => $data['branch_id'] ?? $this->currentBranchId(),
+                        'direction' => $data['direction'] ?? $data['type'] ?? null,
+                        'qty' => $data['qty'] ?? $data['quantity'] ?? null,
+                        'reason' => $data['reason'] ?? null,
+                        'reference_type' => $data['reference_type'] ?? $data['source_type'] ?? null,
+                        'reference_id' => $data['reference_id'] ?? $data['source_id'] ?? null,
+                        'extra_attributes' => $data['extra_attributes'] ?? $data['meta'] ?? [],
+                    ];
 
-                $validator = $this->validator->make($payload, [
-                    'product_id' => ['required', 'integer', 'exists:products,id'],
-                    'warehouse_id' => ['required', 'integer', 'exists:warehouses,id'],
-                    'branch_id' => ['required', 'integer', 'exists:branches,id'],
-                    'direction' => ['required', 'in:in,out'],
-                    'qty' => ['required', 'numeric', 'not_in:0'],
-                ]);
+                    $validator = $this->validator->make($payload, [
+                        'product_id' => ['required', 'integer', 'exists:products,id'],
+                        'warehouse_id' => ['required', 'integer', 'exists:warehouses,id'],
+                        'branch_id' => ['required', 'integer', 'exists:branches,id'],
+                        'direction' => ['required', 'in:in,out'],
+                        'qty' => ['required', 'numeric', 'not_in:0'],
+                    ]);
 
-                $validator->validate();
+                    $validator->validate();
 
-                $payload['created_by'] = $this->currentUser()?->getAuthIdentifier();
+                    $payload['created_by'] = $this->currentUser()?->getAuthIdentifier();
 
-                // Normalize quantity to positive (direction field captures the sign)
-                $payload['qty'] = abs((float) $payload['qty']);
+                    // Normalize quantity to positive (direction field captures the sign)
+                    $payload['qty'] = abs((float) $payload['qty']);
 
                     // Lock product and warehouse rows to prevent races
                     Product::whereKey($payload['product_id'])->lockForUpdate()->first();


### PR DESCRIPTION
## Summary
- remove stale stock movements when updating or deleting warehouse adjustments
- link newly created stock adjustments to their adjustment items and persist metadata
- ensure inventory adjustments store references and extra attributes in stock movements

## Testing
- Not run (environment missing vendor dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a71b716ec8332a1e53f0fbab6a3f4)