### PR TITLE
Harden product image upload validation

### DIFF
--- a/app/Http/Requests/ProductImageRequest.php
+++ b/app/Http/Requests/ProductImageRequest.php
@@ -16,7 +16,14 @@ class ProductImageRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'image' => ['required', 'image'],
+            'image' => [
+                'required',
+                'file',
+                'max:5120', // 5 MB limit to prevent oversized uploads
+                'mimes:jpg,jpeg,png,gif,webp',
+                'mimetypes:image/jpeg,image/png,image/gif,image/webp',
+                'dimensions:max_width=6000,max_height=6000',
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Summary
- tighten product image upload validation with explicit mime whitelists, size limits, and dimension caps to block unsafe payloads
- re-verify stored product image mime types before saving to prevent disguised or malicious files on the public disk

## Testing
- php -l app/Http/Requests/ProductImageRequest.php
- php -l app/Http/Controllers/Branch/ProductController.php
- composer install --no-interaction *(fails: blocked by GitHub 403 while cloning dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a71a749d08324ab74ae47e34f8667)