### PR TITLE
Harden expense and income access controls

### DIFF
--- a/app/Livewire/Expenses/Form.php
+++ b/app/Livewire/Expenses/Form.php
@@ -48,7 +48,7 @@ class Form extends Component
             'amount' => 'required|numeric|min:0',
             'payment_method' => 'nullable|string|max:50',
             'description' => 'nullable|string',
-            'attachment' => 'nullable|file|max:5120|mimes:pdf,jpg,jpeg,png,doc,docx,xls,xlsx,csv,ppt,pptx',
+            'attachment' => 'nullable|file|max:5120|mimes:pdf,jpg,jpeg,png,doc,docx,xls,xlsx,csv,ppt,pptx|mimetypes:application/pdf,image/jpeg,image/png,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/csv',
             'is_recurring' => 'boolean',
             'recurrence_interval' => 'nullable|string|max:50',
         ];


### PR DESCRIPTION
## Summary
- restrict expense listing/export/deletion to the current branch and group search conditions to prevent cross-branch leakage
- enforce branch checks when deleting income records to stop cross-tenant deletions
- tighten expense attachment validation by requiring allowed MIME types in addition to extensions

## Testing
- not run (composer install failed in sandbox due to GitHub 403 responses)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694a82d90ab08324bce7a384c07e0a3b)