### PR TITLE
Add dedicated income and expense category pages

### DIFF
--- a/app/Livewire/Expenses/Categories/Form.php
+++ b/app/Livewire/Expenses/Categories/Form.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Expenses\Categories;
+
+use App\Models\ExpenseCategory;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class Form extends Component
+{
+    use AuthorizesRequests;
+
+    public ?ExpenseCategory $category = null;
+
+    public string $name = '';
+
+    public string $nameAr = '';
+
+    public string $description = '';
+
+    public bool $isActive = true;
+
+    public function mount(?ExpenseCategory $category = null): void
+    {
+        $this->authorize('expenses.manage');
+
+        if ($category && $category->exists) {
+            $this->category = $category;
+            $this->name = $category->name;
+            $this->nameAr = $category->name_ar ?? '';
+            $this->description = $category->description ?? '';
+            $this->isActive = $category->is_active;
+        }
+    }
+
+    public function rules(): array
+    {
+        $branchId = $this->category?->branch_id ?? auth()->user()?->branch_id;
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('expense_categories', 'name')
+                    ->where(fn ($query) => $query->where('branch_id', $branchId))
+                    ->ignore($this->category?->id),
+            ],
+            'nameAr' => 'nullable|string|max:255',
+            'description' => 'nullable|string|max:1000',
+            'isActive' => 'boolean',
+        ];
+    }
+
+    public function save(): void
+    {
+        $data = $this->validate();
+
+        $payload = [
+            'name' => $data['name'],
+            'name_ar' => $data['nameAr'] ?: null,
+            'description' => $data['description'] ?: null,
+            'is_active' => $data['isActive'],
+            'branch_id' => $this->category?->branch_id ?? auth()->user()?->branch_id,
+        ];
+
+        if ($this->category) {
+            $this->category->update($payload);
+            session()->flash('success', __('Category updated successfully'));
+        } else {
+            ExpenseCategory::create($payload);
+            session()->flash('success', __('Category created successfully'));
+        }
+
+        redirect()->route('app.expenses.categories.index');
+    }
+
+    public function render()
+    {
+        return view('livewire.expenses.categories.form');
+    }
+}

--- a/app/Livewire/Expenses/Categories/Index.php
+++ b/app/Livewire/Expenses/Categories/Index.php
@@ -7,7 +7,6 @@ namespace App\Livewire\Expenses\Categories;
 use App\Models\ExpenseCategory;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\Rule;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -19,18 +18,6 @@ class Index extends Component
     use WithPagination;
 
     public string $search = '';
-
-    public bool $showModal = false;
-
-    public ?int $editingId = null;
-
-    public string $name = '';
-
-    public string $nameAr = '';
-
-    public string $description = '';
-
-    public bool $isActive = true;
 
     protected $queryString = ['search'];
 
@@ -59,85 +46,6 @@ class Index extends Component
         return view('livewire.expenses.categories.index', [
             'categories' => $categories,
         ]);
-    }
-
-    public function openModal(): void
-    {
-        $this->resetForm();
-        $this->showModal = true;
-    }
-
-    public function closeModal(): void
-    {
-        $this->showModal = false;
-        $this->resetForm();
-    }
-
-    public function resetForm(): void
-    {
-        $this->editingId = null;
-        $this->name = '';
-        $this->nameAr = '';
-        $this->description = '';
-        $this->isActive = true;
-        $this->resetValidation();
-    }
-
-    public function edit(int $id): void
-    {
-        $category = ExpenseCategory::find($id);
-        if ($category) {
-            $this->editingId = $id;
-            $this->name = $category->name;
-            $this->nameAr = $category->name_ar ?? '';
-            $this->description = $category->description ?? '';
-            $this->isActive = $category->is_active;
-            $this->showModal = true;
-        }
-    }
-
-    public function save(): void
-    {
-        $rules = [
-            'name' => [
-                'required',
-                'string',
-                'max:255',
-                $this->editingId 
-                    ? Rule::unique('expense_categories', 'name')->ignore($this->editingId) 
-                    : Rule::unique('expense_categories', 'name'),
-            ],
-            'nameAr' => 'nullable|string|max:255',
-            'description' => 'nullable|string|max:1000',
-        ];
-
-        $this->validate($rules);
-
-        $user = Auth::user();
-
-        $data = [
-            'name' => $this->name,
-            'name_ar' => $this->nameAr ?: null,
-            'description' => $this->description ?: null,
-            'is_active' => $this->isActive,
-        ];
-
-        try {
-            if ($this->editingId) {
-                $category = ExpenseCategory::findOrFail($this->editingId);
-                $category->update($data);
-                session()->flash('success', __('Category updated successfully'));
-            } else {
-                $data['branch_id'] = $user?->branch_id;
-                ExpenseCategory::create($data);
-                session()->flash('success', __('Category created successfully'));
-            }
-
-            $this->closeModal();
-            $this->resetPage();
-        } catch (\Exception $e) {
-            $this->addError('name', __('Failed to save category. Please try again.'));
-        }
     }
 
     public function delete(int $id): void

--- a/app/Livewire/Income/Categories/Form.php
+++ b/app/Livewire/Income/Categories/Form.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Income\Categories;
+
+use App\Models\IncomeCategory;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+#[Layout('layouts.app')]
+class Form extends Component
+{
+    public ?IncomeCategory $category = null;
+
+    public string $name = '';
+
+    public string $nameAr = '';
+
+    public string $description = '';
+
+    public bool $isActive = true;
+
+    public function mount(?IncomeCategory $category = null): void
+    {
+        $user = Auth::user();
+        if (! $user || ! $user->can('income.manage')) {
+            abort(403);
+        }
+
+        if ($category && $category->exists) {
+            $this->category = $category;
+            $this->name = $category->name;
+            $this->nameAr = $category->name_ar ?? '';
+            $this->description = $category->description ?? '';
+            $this->isActive = $category->is_active;
+        }
+    }
+
+    public function rules(): array
+    {
+        $branchId = $this->category?->branch_id ?? auth()->user()?->branch_id;
+
+        return [
+            'name' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('income_categories', 'name')
+                    ->where(fn ($query) => $query->where('branch_id', $branchId))
+                    ->ignore($this->category?->id),
+            ],
+            'nameAr' => 'nullable|string|max:255',
+            'description' => 'nullable|string|max:1000',
+            'isActive' => 'boolean',
+        ];
+    }
+
+    public function save(): void
+    {
+        $data = $this->validate();
+
+        $payload = [
+            'name' => $data['name'],
+            'name_ar' => $data['nameAr'] ?: null,
+            'description' => $data['description'] ?: null,
+            'is_active' => $data['isActive'],
+            'branch_id' => $this->category?->branch_id ?? auth()->user()?->branch_id,
+        ];
+
+        if ($this->category) {
+            $this->category->update($payload);
+            session()->flash('success', __('Category updated successfully'));
+        } else {
+            IncomeCategory::create($payload);
+            session()->flash('success', __('Category created successfully'));
+        }
+
+        redirect()->route('app.income.categories.index');
+    }
+
+    public function render()
+    {
+        return view('livewire.income.categories.form');
+    }
+}

--- a/app/Livewire/Income/Categories/Index.php
+++ b/app/Livewire/Income/Categories/Index.php
@@ -6,7 +6,6 @@ namespace App\Livewire\Income\Categories;
 
 use App\Models\IncomeCategory;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Validation\Rule;
 use Livewire\Attributes\Layout;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -17,18 +16,6 @@ class Index extends Component
     use WithPagination;
 
     public string $search = '';
-
-    public bool $showModal = false;
-
-    public ?int $editingId = null;
-
-    public string $name = '';
-
-    public string $nameAr = '';
-
-    public string $description = '';
-
-    public bool $isActive = true;
 
     protected $queryString = ['search'];
 
@@ -57,85 +44,6 @@ class Index extends Component
         return view('livewire.income.categories.index', [
             'categories' => $categories,
         ]);
-    }
-
-    public function openModal(): void
-    {
-        $this->resetForm();
-        $this->showModal = true;
-    }
-
-    public function closeModal(): void
-    {
-        $this->showModal = false;
-        $this->resetForm();
-    }
-
-    public function resetForm(): void
-    {
-        $this->editingId = null;
-        $this->name = '';
-        $this->nameAr = '';
-        $this->description = '';
-        $this->isActive = true;
-        $this->resetValidation();
-    }
-
-    public function edit(int $id): void
-    {
-        $category = IncomeCategory::find($id);
-        if ($category) {
-            $this->editingId = $id;
-            $this->name = $category->name;
-            $this->nameAr = $category->name_ar ?? '';
-            $this->description = $category->description ?? '';
-            $this->isActive = $category->is_active;
-            $this->showModal = true;
-        }
-    }
-
-    public function save(): void
-    {
-        $rules = [
-            'name' => [
-                'required',
-                'string',
-                'max:255',
-                $this->editingId 
-                    ? Rule::unique('income_categories', 'name')->ignore($this->editingId) 
-                    : Rule::unique('income_categories', 'name'),
-            ],
-            'nameAr' => 'nullable|string|max:255',
-            'description' => 'nullable|string|max:1000',
-        ];
-
-        $this->validate($rules);
-
-        $user = Auth::user();
-
-        $data = [
-            'name' => $this->name,
-            'name_ar' => $this->nameAr ?: null,
-            'description' => $this->description ?: null,
-            'is_active' => $this->isActive,
-        ];
-
-        try {
-            if ($this->editingId) {
-                $category = IncomeCategory::findOrFail($this->editingId);
-                $category->update($data);
-                session()->flash('success', __('Category updated successfully'));
-            } else {
-                $data['branch_id'] = $user?->branch_id;
-                IncomeCategory::create($data);
-                session()->flash('success', __('Category created successfully'));
-            }
-
-            $this->closeModal();
-            $this->resetPage();
-        } catch (\Exception $e) {
-            $this->addError('name', __('Failed to save category. Please try again.'));
-        }
     }
 
     public function delete(int $id): void

--- a/database/migrations/2025_12_14_000005_add_unique_indexes_to_income_and_expense_categories.php
+++ b/database/migrations/2025_12_14_000005_add_unique_indexes_to_income_and_expense_categories.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('expense_categories', function (Blueprint $table) {
+            $table->unique(['branch_id', 'name'], 'expense_categories_branch_name_unique');
+        });
+
+        Schema::table('income_categories', function (Blueprint $table) {
+            $table->unique(['branch_id', 'name'], 'income_categories_branch_name_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('expense_categories', function (Blueprint $table) {
+            $table->dropUnique('expense_categories_branch_name_unique');
+        });
+
+        Schema::table('income_categories', function (Blueprint $table) {
+            $table->dropUnique('income_categories_branch_name_unique');
+        });
+    }
+};

--- a/resources/views/components/sidebar/module.blade.php
+++ b/resources/views/components/sidebar/module.blade.php
@@ -126,6 +126,7 @@ if (!$module) {
                 <x-sidebar.item route="app.income.index" label="All Income" />
                 @can('income.manage')
                     <x-sidebar.item route="app.income.create" label="New Income" />
+                    <x-sidebar.item route="app.income.categories.index" label="Categories" />
                 @endcan
             @endif
         </ul>

--- a/resources/views/livewire/expenses/categories/form.blade.php
+++ b/resources/views/livewire/expenses/categories/form.blade.php
@@ -1,0 +1,52 @@
+{{-- resources/views/livewire/expenses/categories/form.blade.php --}}
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-xl font-semibold text-slate-800 dark:text-white flex items-center gap-2">
+                <span class="text-2xl">🧾</span>
+                {{ $category ? __('Edit Expense Category') : __('Add Expense Category') }}
+            </h1>
+            <p class="text-sm text-slate-500">{{ __('Create or update expense categories for organizing expenses') }}</p>
+        </div>
+        <div class="flex items-center gap-2">
+            <a href="{{ route('app.expenses.categories.index') }}" class="erp-btn-secondary">{{ __('Back to Categories') }}</a>
+        </div>
+    </div>
+
+    <form wire:submit.prevent="save" class="bg-white dark:bg-slate-800 shadow rounded-2xl p-6 space-y-5">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="erp-label">{{ __('Name') }} <span class="text-red-500">*</span></label>
+                <input type="text" wire:model.live="name" class="erp-input mt-1 @error('name') border-red-500 @enderror" placeholder="{{ __('Category name') }}">
+                @error('name') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+            </div>
+
+            <div>
+                <label class="erp-label">{{ __('Arabic Name') }}</label>
+                <input type="text" wire:model.live="nameAr" class="erp-input mt-1" dir="rtl" placeholder="{{ __('اسم التصنيف') }}">
+                @error('nameAr') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+            </div>
+        </div>
+
+        <div>
+            <label class="erp-label">{{ __('Description') }}</label>
+            <textarea wire:model.live="description" rows="3" class="erp-input mt-1" placeholder="{{ __('Optional description') }}"></textarea>
+            @error('description') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+        </div>
+
+        <div class="flex items-center">
+            <label class="inline-flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" wire:model.live="isActive" class="rounded border-slate-300 text-emerald-600 focus:ring-emerald-500">
+                <span class="text-sm text-slate-700 dark:text-slate-300">{{ __('Active') }}</span>
+            </label>
+        </div>
+
+        <div class="flex justify-end gap-3 pt-4 border-t border-slate-200 dark:border-slate-700">
+            <a href="{{ route('app.expenses.categories.index') }}" class="erp-btn-secondary">{{ __('Cancel') }}</a>
+            <button type="submit" class="erp-btn-primary">
+                <span wire:loading.remove wire:target="save">{{ $category ? __('Save Changes') : __('Create Category') }}</span>
+                <span wire:loading wire:target="save">{{ __('Saving...') }}</span>
+            </button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/expenses/categories/index.blade.php
+++ b/resources/views/livewire/expenses/categories/index.blade.php
@@ -9,12 +9,12 @@
             </h1>
             <p class="text-sm text-slate-500">{{ __('Manage expense categories for organizing expenses') }}</p>
         </div>
-        <button wire:click="openModal" class="erp-btn-primary">
+        <a href="{{ route('app.expenses.categories.create') }}" class="erp-btn-primary">
             <svg class="w-5 h-5 ltr:mr-1 rtl:ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
             </svg>
             {{ __('Add Category') }}
-        </button>
+        </a>
     </div>
 
     @if(session('success'))
@@ -78,13 +78,13 @@
                         </td>
                         <td class="text-center">
                             <div class="flex items-center justify-center gap-1">
-                                <button wire:click="edit({{ $category->id }})" 
-                                        class="erp-btn-icon" 
-                                        title="{{ __('Edit') }}">
+                                <a href="{{ route('app.expenses.categories.edit', $category) }}"
+                                   class="erp-btn-icon"
+                                   title="{{ __('Edit') }}">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                                     </svg>
-                                </button>
+                                </a>
                                 <button wire:click="delete({{ $category->id }})" 
                                         wire:confirm="{{ __('Are you sure you want to delete this category?') }}"
                                         class="erp-btn-icon text-red-500 hover:text-red-700 hover:bg-red-50"
@@ -114,63 +114,3 @@
         {{ $categories->links() }}
     </div>
 </div>
-
-<!-- Modal -->
-@if($showModal)
-    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 overflow-y-auto" wire:click.self="closeModal">
-        <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-xl w-full max-w-lg mx-auto my-auto max-h-[90vh] overflow-y-auto">
-            <div class="px-6 py-4 bg-gradient-to-r from-amber-500 to-amber-600 text-white">
-                <h3 class="text-lg font-semibold flex items-center gap-2">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
-                    </svg>
-                    {{ $editingId ? __('Edit Category') : __('Add Category') }}
-                </h3>
-            </div>
-            <form wire:submit.prevent="save" class="p-6 space-y-4">
-                <div>
-                    <label class="erp-label">{{ __('Name') }} <span class="text-red-500">*</span></label>
-                    <input type="text" wire:model="name" class="erp-input mt-1 @error('name') border-red-500 @enderror" placeholder="{{ __('Category name') }}">
-                    @error('name') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
-                </div>
-
-                <div>
-                    <label class="erp-label">{{ __('Arabic Name') }}</label>
-                    <input type="text" wire:model="nameAr" class="erp-input mt-1" dir="rtl" placeholder="{{ __('اسم التصنيف') }}">
-                    @error('nameAr') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
-                </div>
-
-                <div>
-                    <label class="erp-label">{{ __('Description') }}</label>
-                    <textarea wire:model="description" rows="3" class="erp-input mt-1" placeholder="{{ __('Optional description') }}"></textarea>
-                    @error('description') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
-                </div>
-
-                <div class="flex items-center pt-2">
-                    <label class="inline-flex items-center gap-2 cursor-pointer">
-                        <input type="checkbox" wire:model="isActive" id="isActive" class="rounded border-slate-300 text-emerald-600 focus:ring-emerald-500">
-                        <span class="text-sm text-slate-700 dark:text-slate-300">{{ __('Active') }}</span>
-                    </label>
-                </div>
-
-                <div class="flex justify-end gap-3 pt-4 border-t border-slate-200 dark:border-slate-700">
-                    <button type="button" wire:click="closeModal" class="erp-btn-secondary" wire:loading.attr="disabled">
-                        {{ __('Cancel') }}
-                    </button>
-                    <button type="submit" class="erp-btn-primary" wire:loading.attr="disabled">
-                        <span wire:loading.remove wire:target="save">
-                            {{ $editingId ? __('Save Changes') : __('Create Category') }}
-                        </span>
-                        <span wire:loading wire:target="save">
-                            <svg class="animate-spin h-5 w-5 inline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                            </svg>
-                            {{ __('Saving...') }}
-                        </span>
-                    </button>
-                </div>
-            </form>
-        </div>
-    </div>
-@endif

--- a/resources/views/livewire/income/categories/form.blade.php
+++ b/resources/views/livewire/income/categories/form.blade.php
@@ -1,0 +1,52 @@
+{{-- resources/views/livewire/income/categories/form.blade.php --}}
+<div class="space-y-6">
+    <div class="flex items-center justify-between">
+        <div>
+            <h1 class="text-xl font-semibold text-slate-800 dark:text-white flex items-center gap-2">
+                <span class="text-2xl">📁</span>
+                {{ $category ? __('Edit Income Category') : __('Add Income Category') }}
+            </h1>
+            <p class="text-sm text-slate-500">{{ __('Create or update income categories for organizing income') }}</p>
+        </div>
+        <div class="flex items-center gap-2">
+            <a href="{{ route('app.income.categories.index') }}" class="erp-btn-secondary">{{ __('Back to Categories') }}</a>
+        </div>
+    </div>
+
+    <form wire:submit.prevent="save" class="bg-white dark:bg-slate-800 shadow rounded-2xl p-6 space-y-5">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+                <label class="erp-label">{{ __('Name') }} <span class="text-red-500">*</span></label>
+                <input type="text" wire:model.live="name" class="erp-input mt-1 @error('name') border-red-500 @enderror" placeholder="{{ __('Category name') }}">
+                @error('name') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+            </div>
+
+            <div>
+                <label class="erp-label">{{ __('Arabic Name') }}</label>
+                <input type="text" wire:model.live="nameAr" class="erp-input mt-1" dir="rtl" placeholder="{{ __('اسم التصنيف') }}">
+                @error('nameAr') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+            </div>
+        </div>
+
+        <div>
+            <label class="erp-label">{{ __('Description') }}</label>
+            <textarea wire:model.live="description" rows="3" class="erp-input mt-1" placeholder="{{ __('Optional description') }}"></textarea>
+            @error('description') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
+        </div>
+
+        <div class="flex items-center">
+            <label class="inline-flex items-center gap-2 cursor-pointer">
+                <input type="checkbox" wire:model.live="isActive" class="rounded border-slate-300 text-emerald-600 focus:ring-emerald-500">
+                <span class="text-sm text-slate-700 dark:text-slate-300">{{ __('Active') }}</span>
+            </label>
+        </div>
+
+        <div class="flex justify-end gap-3 pt-4 border-t border-slate-200 dark:border-slate-700">
+            <a href="{{ route('app.income.categories.index') }}" class="erp-btn-secondary">{{ __('Cancel') }}</a>
+            <button type="submit" class="erp-btn-primary">
+                <span wire:loading.remove wire:target="save">{{ $category ? __('Save Changes') : __('Create Category') }}</span>
+                <span wire:loading wire:target="save">{{ __('Saving...') }}</span>
+            </button>
+        </div>
+    </form>
+</div>

--- a/resources/views/livewire/income/categories/index.blade.php
+++ b/resources/views/livewire/income/categories/index.blade.php
@@ -9,12 +9,12 @@
             </h1>
             <p class="text-sm text-slate-500">{{ __('Manage income categories for organizing income') }}</p>
         </div>
-        <button wire:click="openModal" class="erp-btn-primary">
+        <a href="{{ route('app.income.categories.create') }}" class="erp-btn-primary">
             <svg class="w-5 h-5 ltr:mr-1 rtl:ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
             </svg>
             {{ __('Add Category') }}
-        </button>
+        </a>
     </div>
 
     @if(session('success'))
@@ -78,13 +78,13 @@
                         </td>
                         <td class="text-center">
                             <div class="flex items-center justify-center gap-1">
-                                <button wire:click="edit({{ $category->id }})" 
-                                        class="erp-btn-icon" 
-                                        title="{{ __('Edit') }}">
+                                <a href="{{ route('app.income.categories.edit', $category) }}"
+                                   class="erp-btn-icon"
+                                   title="{{ __('Edit') }}">
                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
                                     </svg>
-                                </button>
+                                </a>
                                 <button wire:click="delete({{ $category->id }})" 
                                         wire:confirm="{{ __('Are you sure you want to delete this category?') }}"
                                         class="erp-btn-icon text-red-500 hover:text-red-700 hover:bg-red-50"
@@ -114,63 +114,3 @@
         {{ $categories->links() }}
     </div>
 </div>
-
-<!-- Modal -->
-@if($showModal)
-    <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4 overflow-y-auto" wire:click.self="closeModal">
-        <div class="bg-white dark:bg-slate-800 rounded-2xl shadow-xl w-full max-w-lg mx-auto my-auto max-h-[90vh] overflow-y-auto">
-            <div class="px-6 py-4 bg-gradient-to-r from-blue-500 to-blue-600 text-white">
-                <h3 class="text-lg font-semibold flex items-center gap-2">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/>
-                    </svg>
-                    {{ $editingId ? __('Edit Category') : __('Add Category') }}
-                </h3>
-            </div>
-            <form wire:submit.prevent="save" class="p-6 space-y-4">
-                <div>
-                    <label class="erp-label">{{ __('Name') }} <span class="text-red-500">*</span></label>
-                    <input type="text" wire:model="name" class="erp-input mt-1 @error('name') border-red-500 @enderror" placeholder="{{ __('Category name') }}">
-                    @error('name') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
-                </div>
-
-                <div>
-                    <label class="erp-label">{{ __('Arabic Name') }}</label>
-                    <input type="text" wire:model="nameAr" class="erp-input mt-1" dir="rtl" placeholder="{{ __('اسم التصنيف') }}">
-                    @error('nameAr') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
-                </div>
-
-                <div>
-                    <label class="erp-label">{{ __('Description') }}</label>
-                    <textarea wire:model="description" rows="3" class="erp-input mt-1" placeholder="{{ __('Optional description') }}"></textarea>
-                    @error('description') <p class="text-xs text-red-500 mt-1">{{ $message }}</p> @enderror
-                </div>
-
-                <div class="flex items-center pt-2">
-                    <label class="inline-flex items-center gap-2 cursor-pointer">
-                        <input type="checkbox" wire:model="isActive" id="isActive" class="rounded border-slate-300 text-emerald-600 focus:ring-emerald-500">
-                        <span class="text-sm text-slate-700 dark:text-slate-300">{{ __('Active') }}</span>
-                    </label>
-                </div>
-
-                <div class="flex justify-end gap-3 pt-4 border-t border-slate-200 dark:border-slate-700">
-                    <button type="button" wire:click="closeModal" class="erp-btn-secondary" wire:loading.attr="disabled">
-                        {{ __('Cancel') }}
-                    </button>
-                    <button type="submit" class="erp-btn-primary" wire:loading.attr="disabled">
-                        <span wire:loading.remove wire:target="save">
-                            {{ $editingId ? __('Save Changes') : __('Create Category') }}
-                        </span>
-                        <span wire:loading wire:target="save">
-                            <svg class="animate-spin h-5 w-5 inline" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                            </svg>
-                            {{ __('Saving...') }}
-                        </span>
-                    </button>
-                </div>
-            </form>
-        </div>
-    </div>
-@endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -749,6 +749,14 @@ Route::get('/app/media/{media}/download', \App\Http\Controllers\Admin\MediaDownl
         Route::get('/categories', \App\Livewire\Expenses\Categories\Index::class)
             ->name('categories.index')
             ->middleware('can:expenses.manage');
+
+        Route::get('/categories/create', \App\Livewire\Expenses\Categories\Form::class)
+            ->name('categories.create')
+            ->middleware('can:expenses.manage');
+
+        Route::get('/categories/{category}/edit', \App\Livewire\Expenses\Categories\Form::class)
+            ->name('categories.edit')
+            ->middleware('can:expenses.manage');
     });
 
     Route::prefix('app/income')->name('app.income.')->group(function () {
@@ -766,6 +774,14 @@ Route::get('/app/media/{media}/download', \App\Http\Controllers\Admin\MediaDownl
 
         Route::get('/categories', \App\Livewire\Income\Categories\Index::class)
             ->name('categories.index')
+            ->middleware('can:income.manage');
+
+        Route::get('/categories/create', \App\Livewire\Income\Categories\Form::class)
+            ->name('categories.create')
+            ->middleware('can:income.manage');
+
+        Route::get('/categories/{category}/edit', \App\Livewire\Income\Categories\Form::class)
+            ->name('categories.edit')
             ->middleware('can:income.manage');
     });
 


### PR DESCRIPTION
## Summary
- add dedicated create/edit pages for income and expense categories with full forms
- update category lists to link to the new pages and simplify CRUD actions
- register routes for the new category form pages
- enforce branch-scoped uniqueness for category names through validation and database unique indexes to prevent duplicates

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c5f7347d4833397bf06c6d5d8c825)