### PR TITLE
Align category and shift forms with page layouts

### DIFF
--- a/resources/views/livewire/expenses/categories/form.blade.php
+++ b/resources/views/livewire/expenses/categories/form.blade.php
@@ -1,5 +1,5 @@
 {{-- resources/views/livewire/expenses/categories/form.blade.php --}}
-<div class="space-y-6">
+<div class="space-y-6 max-w-3xl mx-auto">
     <div class="flex items-center justify-between">
         <div>
             <h1 class="text-xl font-semibold text-slate-800 dark:text-white flex items-center gap-2">

--- a/resources/views/livewire/hrm/shifts/form.blade.php
+++ b/resources/views/livewire/hrm/shifts/form.blade.php
@@ -1,5 +1,5 @@
 {{-- resources/views/livewire/hrm/shifts/form.blade.php --}}
-<div class="space-y-4">
+<div class="space-y-6 max-w-3xl mx-auto">
     <div class="flex items-center justify-between gap-2">
         <div>
             <h1 class="text-lg font-semibold text-slate-800 dark:text-slate-100">
@@ -9,6 +9,10 @@
                 {{ __('Configure work shift settings for employees.') }}
             </p>
         </div>
+
+        <a href="{{ route('app.hrm.shifts.index') }}" class="erp-btn-secondary text-sm">
+            {{ __('Back to Shifts') }}
+        </a>
     </div>
 
     @if(session()->has('success'))

--- a/resources/views/livewire/income/categories/form.blade.php
+++ b/resources/views/livewire/income/categories/form.blade.php
@@ -1,5 +1,5 @@
 {{-- resources/views/livewire/income/categories/form.blade.php --}}
-<div class="space-y-6">
+<div class="space-y-6 max-w-3xl mx-auto">
     <div class="flex items-center justify-between">
         <div>
             <h1 class="text-xl font-semibold text-slate-800 dark:text-white flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Center expense and income category forms in dedicated page layouts
- Add a back-to-list action and centered layout to the HRM shift form

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c800245648333bd0634d0703b0ea1)