### PR TITLE
Convert compatibility modals to inline forms

### DIFF
--- a/app/Livewire/Inventory/ProductCompatibility.php
+++ b/app/Livewire/Inventory/ProductCompatibility.php
@@ -45,9 +45,9 @@ class ProductCompatibility extends Component
 
     public bool $isVerified = false;
 
-    public bool $showVehicleModal = false;
+    public bool $showVehicleForm = false;
 
-    public bool $showCompatibilityModal = false;
+    public bool $showCompatibilityForm = false;
 
     protected SparePartsService $sparePartsService;
 
@@ -98,15 +98,15 @@ class ProductCompatibility extends Component
         ]);
     }
 
-    public function openVehicleModal(): void
+    public function openVehicleForm(): void
     {
         $this->resetVehicleForm();
-        $this->showVehicleModal = true;
+        $this->showVehicleForm = true;
     }
 
-    public function closeVehicleModal(): void
+    public function closeVehicleForm(): void
     {
-        $this->showVehicleModal = false;
+        $this->showVehicleForm = false;
         $this->resetVehicleForm();
     }
 
@@ -132,7 +132,7 @@ class ProductCompatibility extends Component
             $this->newYearTo = $vehicle->year_to;
             $this->newCategory = $vehicle->category ?? '';
             $this->newEngineType = $vehicle->engine_type ?? '';
-            $this->showVehicleModal = true;
+            $this->showVehicleForm = true;
         }
     }
 
@@ -163,7 +163,7 @@ class ProductCompatibility extends Component
             $this->dispatch('notify', type: 'success', message: __('Vehicle model created successfully'));
         }
 
-        $this->closeVehicleModal();
+        $this->closeVehicleForm();
     }
 
     public function deleteVehicle(int $id): void
@@ -172,15 +172,15 @@ class ProductCompatibility extends Component
         $this->dispatch('notify', type: 'success', message: __('Vehicle model deleted successfully'));
     }
 
-    public function openCompatibilityModal(): void
+    public function openCompatibilityForm(): void
     {
         $this->resetCompatibilityForm();
-        $this->showCompatibilityModal = true;
+        $this->showCompatibilityForm = true;
     }
 
-    public function closeCompatibilityModal(): void
+    public function closeCompatibilityForm(): void
     {
-        $this->showCompatibilityModal = false;
+        $this->showCompatibilityForm = false;
         $this->resetCompatibilityForm();
     }
 
@@ -213,7 +213,7 @@ class ProductCompatibility extends Component
         );
 
         $this->dispatch('notify', type: 'success', message: __('Compatibility added successfully'));
-        $this->closeCompatibilityModal();
+        $this->closeCompatibilityForm();
     }
 
     public function quickAddCompatibility(int $vehicleModelId): void

--- a/resources/views/livewire/inventory/product-compatibility.blade.php
+++ b/resources/views/livewire/inventory/product-compatibility.blade.php
@@ -5,7 +5,7 @@
             <div class="bg-white dark:bg-gray-800 rounded-lg shadow">
                 <div class="p-4 border-b border-gray-200 dark:border-gray-700 flex justify-between items-center">
                     <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ __('Vehicle Models') }}</h3>
-                    <button wire:click="openVehicleModal" class="px-3 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm">
+                    <button wire:click="openVehicleForm" class="px-3 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm">
                         <x-icon name="plus" class="w-4 h-4 inline-block" /> {{ __('Add Vehicle') }}
                     </button>
                 </div>
@@ -97,7 +97,7 @@
                         @endif
                     </h3>
                     @if($product)
-                        <button wire:click="openCompatibilityModal" class="px-3 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm">
+                        <button wire:click="openCompatibilityForm" class="px-3 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 text-sm">
                             <x-icon name="plus" class="w-4 h-4 inline-block" /> {{ __('Add Details') }}
                         </button>
                     @endif
@@ -163,159 +163,167 @@
         </div>
     </div>
 
-    <!-- Vehicle Model Modal -->
-    @if($showVehicleModal)
-        <div class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
-            <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:p-0">
-                <div class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75" wire:click="closeVehicleModal"></div>
-                
-                <div class="relative inline-block w-full max-w-md p-6 overflow-hidden text-left align-middle transition-all transform bg-white dark:bg-gray-800 rounded-xl shadow-xl">
-                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+    <!-- Vehicle Model Form -->
+    @if($showVehicleForm)
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow border border-gray-100 dark:border-gray-700">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
                         {{ $editingId ? __('Edit Vehicle Model') : __('Add Vehicle Model') }}
                     </h3>
-                    
-                    <form wire:submit="saveVehicle" class="space-y-4">
-                        <div class="grid grid-cols-2 gap-4">
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Brand') }} *</label>
-                                <input type="text" wire:model="newBrand" list="brands-list"
-                                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                                <datalist id="brands-list">
-                                    @foreach($brands as $brand)
-                                        <option value="{{ $brand }}">
-                                    @endforeach
-                                </datalist>
-                                @error('newBrand') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
-                            </div>
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Model') }} *</label>
-                                <input type="text" wire:model="newModel"
-                                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                                @error('newModel') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
-                            </div>
-                        </div>
-                        
-                        <div class="grid grid-cols-2 gap-4">
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Year From') }}</label>
-                                <input type="number" wire:model="newYearFrom" min="1900" max="2100"
-                                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                            </div>
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Year To') }}</label>
-                                <input type="number" wire:model="newYearTo" min="1900" max="2100"
-                                       class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                            </div>
-                        </div>
-
-                        <div class="grid grid-cols-2 gap-4">
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Category') }}</label>
-                                <select wire:model="newCategory" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                                    <option value="">{{ __('Select...') }}</option>
-                                    <option value="sedan">{{ __('Sedan') }}</option>
-                                    <option value="suv">{{ __('SUV') }}</option>
-                                    <option value="truck">{{ __('Truck') }}</option>
-                                    <option value="van">{{ __('Van') }}</option>
-                                    <option value="motorcycle">{{ __('Motorcycle') }}</option>
-                                    <option value="bus">{{ __('Bus') }}</option>
-                                </select>
-                            </div>
-                            <div>
-                                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Engine Type') }}</label>
-                                <select wire:model="newEngineType" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                                    <option value="">{{ __('Select...') }}</option>
-                                    <option value="gasoline">{{ __('Gasoline') }}</option>
-                                    <option value="diesel">{{ __('Diesel') }}</option>
-                                    <option value="electric">{{ __('Electric') }}</option>
-                                    <option value="hybrid">{{ __('Hybrid') }}</option>
-                                </select>
-                            </div>
-                        </div>
-
-                        <div class="flex justify-end gap-3 mt-6">
-                            <button type="button" wire:click="closeVehicleModal" 
-                                    class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
-                                {{ __('Cancel') }}
-                            </button>
-                            <button type="submit" class="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700">
-                                {{ $editingId ? __('Update') : __('Create') }}
-                            </button>
-                        </div>
-                    </form>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('Fill in the vehicle details below.') }}</p>
                 </div>
+                <button type="button" wire:click="closeVehicleForm" class="text-gray-400 hover:text-red-500">
+                    <x-icon name="x-mark" class="w-5 h-5" />
+                </button>
+            </div>
+
+            <div class="p-6">
+                <form wire:submit="saveVehicle" class="space-y-4">
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Brand') }} *</label>
+                            <input type="text" wire:model="newBrand" list="brands-list"
+                                   class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                            <datalist id="brands-list">
+                                @foreach($brands as $brand)
+                                    <option value="{{ $brand }}">
+                                @endforeach
+                            </datalist>
+                            @error('newBrand') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Model') }} *</label>
+                            <input type="text" wire:model="newModel"
+                                   class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                            @error('newModel') <span class="text-red-500 text-xs">{{ $message }}</span> @enderror
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Year From') }}</label>
+                            <input type="number" wire:model="newYearFrom" min="1900" max="2100"
+                                   class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Year To')}}</label>
+                            <input type="number" wire:model="newYearTo" min="1900" max="2100"
+                                   class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Category') }}</label>
+                            <select wire:model="newCategory" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                                <option value="">{{ __('Select...') }}</option>
+                                <option value="sedan">{{ __('Sedan') }}</option>
+                                <option value="suv">{{ __('SUV') }}</option>
+                                <option value="truck">{{ __('Truck') }}</option>
+                                <option value="van">{{ __('Van') }}</option>
+                                <option value="motorcycle">{{ __('Motorcycle') }}</option>
+                                <option value="bus">{{ __('Bus') }}</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Engine Type') }}</label>
+                            <select wire:model="newEngineType" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                                <option value="">{{ __('Select...') }}</option>
+                                <option value="gasoline">{{ __('Gasoline') }}</option>
+                                <option value="diesel">{{ __('Diesel') }}</option>
+                                <option value="electric">{{ __('Electric') }}</option>
+                                <option value="hybrid">{{ __('Hybrid') }}</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="flex justify-end gap-3 pt-2">
+                        <button type="button" wire:click="closeVehicleForm"
+                                class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
+                            {{ __('Cancel') }}
+                        </button>
+                        <button type="submit" class="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700">
+                            {{ $editingId ? __('Update') : __('Create') }}
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     @endif
 
-    <!-- Compatibility Details Modal -->
-    @if($showCompatibilityModal)
-        <div class="fixed inset-0 z-50 overflow-y-auto" aria-modal="true">
-            <div class="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:p-0">
-                <div class="fixed inset-0 transition-opacity bg-gray-500 bg-opacity-75" wire:click="closeCompatibilityModal"></div>
-                
-                <div class="relative inline-block w-full max-w-md p-6 overflow-hidden text-left align-middle transition-all transform bg-white dark:bg-gray-800 rounded-xl shadow-xl">
-                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{{ __('Add Compatibility with Details') }}</h3>
-                    
-                    <form wire:submit="addCompatibility" class="space-y-4">
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Vehicle Model') }} *</label>
-                            <select wire:model="selectedVehicleId" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                                <option value="">{{ __('Select Vehicle...') }}</option>
-                                @foreach(App\Models\VehicleModel::active()->orderBy('brand')->orderBy('model')->get() as $vehicle)
-                                    <option value="{{ $vehicle->id }}">{{ $vehicle->display_name }}</option>
-                                @endforeach
-                            </select>
-                        </div>
-                        
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('OEM Number') }}</label>
-                            <input type="text" wire:model="oemNumber" placeholder="{{ __('e.g., 11427953129') }}"
-                                   class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                        </div>
-                        
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Position') }}</label>
-                            <select wire:model="position" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
-                                <option value="">{{ __('Select...') }}</option>
-                                <option value="front">{{ __('Front') }}</option>
-                                <option value="rear">{{ __('Rear') }}</option>
-                                <option value="left">{{ __('Left') }}</option>
-                                <option value="right">{{ __('Right') }}</option>
-                                <option value="front_left">{{ __('Front Left') }}</option>
-                                <option value="front_right">{{ __('Front Right') }}</option>
-                                <option value="rear_left">{{ __('Rear Left') }}</option>
-                                <option value="rear_right">{{ __('Rear Right') }}</option>
-                                <option value="engine">{{ __('Engine') }}</option>
-                                <option value="transmission">{{ __('Transmission') }}</option>
-                                <option value="interior">{{ __('Interior') }}</option>
-                                <option value="exterior">{{ __('Exterior') }}</option>
-                            </select>
-                        </div>
-
-                        <div>
-                            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Notes') }}</label>
-                            <textarea wire:model="notes" rows="2"
-                                      class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white"></textarea>
-                        </div>
-
-                        <div class="flex items-center">
-                            <input type="checkbox" wire:model="isVerified" id="is_verified" 
-                                   class="w-4 h-4 text-emerald-600 border-gray-300 rounded focus:ring-emerald-500">
-                            <label for="is_verified" class="ml-2 text-sm text-gray-700 dark:text-gray-300">{{ __('Mark as Verified') }}</label>
-                        </div>
-
-                        <div class="flex justify-end gap-3 mt-6">
-                            <button type="button" wire:click="closeCompatibilityModal" 
-                                    class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
-                                {{ __('Cancel') }}
-                            </button>
-                            <button type="submit" class="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700">
-                                {{ __('Add Compatibility') }}
-                            </button>
-                        </div>
-                    </form>
+    <!-- Compatibility Details Form -->
+    @if($showCompatibilityForm)
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow border border-gray-100 dark:border-gray-700">
+            <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+                <div>
+                    <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{{ __('Add Compatibility with Details') }}</h3>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('Select a vehicle and provide optional details.') }}</p>
                 </div>
+                <button type="button" wire:click="closeCompatibilityForm" class="text-gray-400 hover:text-red-500">
+                    <x-icon name="x-mark" class="w-5 h-5" />
+                </button>
+            </div>
+
+            <div class="p-6">
+                <form wire:submit="addCompatibility" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Vehicle Model') }} *</label>
+                        <select wire:model="selectedVehicleId" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                            <option value="">{{ __('Select Vehicle...') }}</option>
+                            @foreach(App\Models\VehicleModel::active()->orderBy('brand')->orderBy('model')->get() as $vehicle)
+                                <option value="{{ $vehicle->id }}">{{ $vehicle->display_name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('OEM Number') }}</label>
+                        <input type="text" wire:model="oemNumber" placeholder="{{ __('e.g., 11427953129') }}"
+                               class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Position') }}</label>
+                        <select wire:model="position" class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white">
+                            <option value="">{{ __('Select...') }}</option>
+                            <option value="front">{{ __('Front') }}</option>
+                            <option value="rear">{{ __('Rear') }}</option>
+                            <option value="left">{{ __('Left') }}</option>
+                            <option value="right">{{ __('Right') }}</option>
+                            <option value="front_left">{{ __('Front Left') }}</option>
+                            <option value="front_right">{{ __('Front Right') }}</option>
+                            <option value="rear_left">{{ __('Rear Left') }}</option>
+                            <option value="rear_right">{{ __('Rear Right') }}</option>
+                            <option value="engine">{{ __('Engine') }}</option>
+                            <option value="transmission">{{ __('Transmission') }}</option>
+                            <option value="interior">{{ __('Interior') }}</option>
+                            <option value="exterior">{{ __('Exterior') }}</option>
+                        </select>
+                    </div>
+
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ __('Notes') }}</label>
+                        <textarea wire:model="notes" rows="2"
+                                  class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg dark:bg-gray-700 dark:text-white"></textarea>
+                    </div>
+
+                    <div class="flex items-center">
+                        <input type="checkbox" wire:model="isVerified" id="is_verified"
+                               class="w-4 h-4 text-emerald-600 border-gray-300 rounded focus:ring-emerald-500">
+                        <label for="is_verified" class="ml-2 text-sm text-gray-700 dark:text-gray-300">{{ __('Mark as Verified') }}</label>
+                    </div>
+
+                    <div class="flex justify-end gap-3 pt-2">
+                        <button type="button" wire:click="closeCompatibilityForm"
+                                class="px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700">
+                            {{ __('Cancel') }}
+                        </button>
+                        <button type="submit" class="px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700">
+                            {{ __('Add Compatibility') }}
+                        </button>
+                    </div>
+                </form>
             </div>
         </div>
     @endif


### PR DESCRIPTION
## Summary
- replace product compatibility vehicle and details modals with inline page forms
- rename Livewire state flags and actions to reflect form-based workflow

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c8140deb88333a452a62a36115f5a)