### PR TITLE
Add soft deletes to price groups and taxes

### DIFF
--- a/database/migrations/2025_12_31_180000_add_soft_deletes_to_price_groups_and_taxes.php
+++ b/database/migrations/2025_12_31_180000_add_soft_deletes_to_price_groups_and_taxes.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('price_groups')) {
+            Schema::table('price_groups', function (Blueprint $table): void {
+                if (! Schema::hasColumn('price_groups', 'deleted_at')) {
+                    $table->softDeletes();
+                }
+            });
+        }
+
+        if (Schema::hasTable('taxes')) {
+            Schema::table('taxes', function (Blueprint $table): void {
+                if (! Schema::hasColumn('taxes', 'deleted_at')) {
+                    $table->softDeletes();
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('price_groups')) {
+            Schema::table('price_groups', function (Blueprint $table): void {
+                if (Schema::hasColumn('price_groups', 'deleted_at')) {
+                    $table->dropSoftDeletes();
+                }
+            });
+        }
+
+        if (Schema::hasTable('taxes')) {
+            Schema::table('taxes', function (Blueprint $table): void {
+                if (Schema::hasColumn('taxes', 'deleted_at')) {
+                    $table->dropSoftDeletes();
+                }
+            });
+        }
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration to introduce soft delete support to price groups and taxes tables
- guard the new columns with schema checks to avoid collisions when rerunning migrations

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c81a12cd88333ad3d43c98d2c315b)