### PR TITLE
Link category quick-add to create pages

### DIFF
--- a/resources/views/livewire/expenses/form.blade.php
+++ b/resources/views/livewire/expenses/form.blade.php
@@ -11,8 +11,8 @@
             <div>
                 <div class="flex items-center justify-between">
                     <label class="erp-label">{{ __('Category') }}</label>
-                    <x-quick-add-link 
-                        :route="route('app.expenses.categories.index')" 
+                    <x-quick-add-link
+                        :route="route('app.expenses.categories.create')"
                         label="{{ __('Add Category') }}"
                         permission="expenses.manage" />
                 </div>

--- a/resources/views/livewire/income/form.blade.php
+++ b/resources/views/livewire/income/form.blade.php
@@ -11,8 +11,8 @@
             <div>
                 <div class="flex items-center justify-between">
                     <label class="erp-label">{{ __('Category') }}</label>
-                    <x-quick-add-link 
-                        :route="route('app.income.categories.index')" 
+                    <x-quick-add-link
+                        :route="route('app.income.categories.create')"
                         label="{{ __('Add Category') }}"
                         permission="income.manage" />
                 </div>


### PR DESCRIPTION
## Summary
- update income quick add link to target the dedicated income category creation page
- update expense quick add link to target the expense category creation page

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c836ed9248333aec660d1e7796149)