### PR TITLE
Fix export column mapping for sales and purchases

### DIFF
--- a/app/Livewire/Purchases/Index.php
+++ b/app/Livewire/Purchases/Index.php
@@ -99,7 +99,7 @@ class Index extends Component
             ->select([
                 'purchases.id',
                 'purchases.code as reference',
-                'purchases.created_at as purchase_date',
+                'purchases.created_at as posted_at',
                 'suppliers.name as supplier_name',
                 'purchases.grand_total',
                 'purchases.paid_total as amount_paid',

--- a/app/Livewire/Sales/Index.php
+++ b/app/Livewire/Sales/Index.php
@@ -127,7 +127,7 @@ class Index extends Component
             ->select([
                 'sales.id',
                 'sales.code as reference',
-                'sales.created_at as sale_date',
+                'sales.created_at as posted_at',
                 'customers.name as customer_name',
                 'sales.grand_total',
                 'sales.paid_total as amount_paid',


### PR DESCRIPTION
## Summary
- align sales export date column with available export configuration
- align purchase export date column with available export configuration

## Testing
- ⚠️ `phpunit --filter ExportDownloadAuthorizationTest` *(phpunit executable not available in PATH)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6959139a6d808333b25019a58b808614)