### PR TITLE
Ensure typed Livewire actions return explicit values

### DIFF
--- a/app/Livewire/Admin/Currency/Form.php
+++ b/app/Livewire/Admin/Currency/Form.php
@@ -107,7 +107,7 @@ class Form extends Component
             } elseif (! $this->isBase && $currency->is_base) {
                 session()->flash('error', __('Cannot unset base currency. Set another currency as base first.'));
 
-                return;
+                return null;
             }
 
             $currency->update($data);

--- a/app/Livewire/Admin/CurrencyRate/Form.php
+++ b/app/Livewire/Admin/CurrencyRate/Form.php
@@ -74,7 +74,7 @@ class Form extends Component
         if ($this->fromCurrency === $this->toCurrency) {
             session()->flash('error', __('From and To currencies must be different'));
 
-            return;
+            return null;
         }
 
         $this->currencyService->setRate(

--- a/app/Livewire/Admin/Modules/ProductFields/Form.php
+++ b/app/Livewire/Admin/Modules/ProductFields/Form.php
@@ -167,7 +167,7 @@ class Form extends Component
         if (! $this->moduleId) {
             session()->flash('error', __('Please select a module before saving a field.'));
 
-            return;
+            return null;
         }
 
         $options = array_filter(array_map('trim', explode("\n", $this->optionsText)));

--- a/app/Livewire/Admin/Roles/Form.php
+++ b/app/Livewire/Admin/Roles/Form.php
@@ -59,7 +59,7 @@ class Form extends Component
         if ($editMode && $role->name === 'Super Admin') {
             session()->flash('error', __('Cannot modify Super Admin role'));
 
-            return;
+            return null;
         }
 
         return $this->handleOperation(

--- a/app/Livewire/Admin/Settings/SystemSettings.php
+++ b/app/Livewire/Admin/Settings/SystemSettings.php
@@ -151,7 +151,7 @@ class SystemSettings extends Component
         }
 
         if ($this->getErrorBag()->isNotEmpty()) {
-            return;
+            return null;
         }
 
         // نقرأ الإعدادات القديمة عشان نقدر نسجل الـ changes في الـ audit log

--- a/app/Livewire/Hrm/Payroll/Run.php
+++ b/app/Livewire/Hrm/Payroll/Run.php
@@ -57,7 +57,7 @@ class Run extends Component
         if (! $this->branchId) {
             session()->flash('error', __('Branch is not set for current user.'));
 
-            return;
+            return null;
         }
 
         DB::transaction(function () {

--- a/app/Livewire/Inventory/ProductStoreMappings/Form.php
+++ b/app/Livewire/Inventory/ProductStoreMappings/Form.php
@@ -165,14 +165,14 @@ class Form extends Component
             } catch (\Illuminate\Database\UniqueConstraintViolationException $e) {
                 $this->addError('store_id', __('This product is already mapped to this store'));
 
-                return;
+                return null;
             } catch (\Illuminate\Database\QueryException $e) {
                 // Fallback for older Laravel or PDO drivers that don't throw UniqueConstraintViolationException
                 $errorCode = $e->errorInfo[1] ?? 0;
                 if ($errorCode === 1062 || $errorCode === 19 || $errorCode === 2627) {
                     $this->addError('store_id', __('This product is already mapped to this store'));
 
-                    return;
+                    return null;
                 }
                 throw $e;
             }

--- a/app/Livewire/Inventory/Products/Form.php
+++ b/app/Livewire/Inventory/Products/Form.php
@@ -339,15 +339,15 @@ class Form extends Component
                 // Create new product - require module selection
                 if (!$this->form['module_id']) {
                     $this->addError('form.module_id', __('Please select a module for this product'));
-                    return;
+                    return null;
                 }
 
                 $module = Module::findOrFail($this->form['module_id']);
-                
+
                 // Verify module supports items
                 if (!$module->supportsItems()) {
                     $this->addError('form.module_id', __('Selected module does not support items/products'));
-                    return;
+                    return null;
                 }
 
                 $this->productService->createProductForModule(

--- a/app/Livewire/Manufacturing/BillsOfMaterials/Form.php
+++ b/app/Livewire/Manufacturing/BillsOfMaterials/Form.php
@@ -80,10 +80,10 @@ class Form extends Component
 
         $user = auth()->user();
         $branchId = $user->branch_id ?? Branch::first()?->id;
-        
+
         if (!$branchId) {
             session()->flash('error', __('No branch available. Please contact your administrator.'));
-            return;
+            return null;
         }
 
         $data = [

--- a/app/Livewire/Manufacturing/ProductionOrders/Form.php
+++ b/app/Livewire/Manufacturing/ProductionOrders/Form.php
@@ -85,10 +85,10 @@ class Form extends Component
 
         $user = auth()->user();
         $branchId = $user->branch_id ?? Branch::first()?->id;
-        
+
         if (!$branchId) {
             session()->flash('error', __('No branch available. Please contact your administrator.'));
-            return;
+            return null;
         }
 
         $data = [

--- a/app/Livewire/Manufacturing/WorkCenters/Form.php
+++ b/app/Livewire/Manufacturing/WorkCenters/Form.php
@@ -82,10 +82,10 @@ class Form extends Component
 
         $user = auth()->user();
         $branchId = $user->branch_id ?? Branch::first()?->id;
-        
+
         if (!$branchId) {
             session()->flash('error', __('No branch available. Please contact your administrator.'));
-            return;
+            return null;
         }
 
         $data = [

--- a/app/Livewire/Purchases/Form.php
+++ b/app/Livewire/Purchases/Form.php
@@ -277,7 +277,7 @@ class Form extends Component
     {
         // BUG-010 Fix: Prevent double submission
         if ($this->isSubmitting) {
-            return;
+            return null;
         }
         $this->isSubmitting = true;
 

--- a/app/Livewire/Sales/Form.php
+++ b/app/Livewire/Sales/Form.php
@@ -300,7 +300,7 @@ class Form extends Component
     {
         // BUG-010 Fix: Prevent double submission
         if ($this->isSubmitting) {
-            return;
+            return null;
         }
         $this->isSubmitting = true;
 


### PR DESCRIPTION
## Summary
- return `null` instead of bare `return;` in typed Livewire actions to satisfy declared return types
- cover sales, purchases, inventory, HRM, manufacturing, currency, and settings forms to avoid fatal errors on early exits

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695972f4c3b083339b1d55be38432581)