### PR TITLE
Fix hasAttribute visibility in CommonQueryScopes

### DIFF
--- a/app/Models/Traits/CommonQueryScopes.php
+++ b/app/Models/Traits/CommonQueryScopes.php
@@ -153,9 +153,9 @@ trait CommonQueryScopes
     /**
      * Check if model has an attribute
      */
-    protected function hasAttribute(string $attribute): bool
+    public function hasAttribute(string $attribute): bool
     {
-        return in_array($attribute, $this->fillable ?? []) || 
+        return in_array($attribute, $this->fillable ?? []) ||
                array_key_exists($attribute, $this->casts ?? []);
     }
 


### PR DESCRIPTION
## Summary
- adjust CommonQueryScopes::hasAttribute visibility to public to match the Eloquent Model signature and prevent package discovery failures

## Testing
- not run (vendor dependencies not installed in environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d8ce95e9c83339d1c15497fc1d6e9)