### PR TITLE
Fix hasAttribute signature compatibility

### DIFF
--- a/app/Models/Traits/CommonQueryScopes.php
+++ b/app/Models/Traits/CommonQueryScopes.php
@@ -153,10 +153,16 @@ trait CommonQueryScopes
     /**
      * Check if model has an attribute
      */
-    public function hasAttribute(string $attribute): bool
+    public function hasAttribute($key): bool
     {
-        return in_array($attribute, $this->fillable ?? []) ||
-               array_key_exists($attribute, $this->casts ?? []);
+        $parentClass = get_parent_class($this);
+
+        if ($parentClass && is_callable([$parentClass, 'hasAttribute']) && parent::hasAttribute($key)) {
+            return true;
+        }
+
+        return in_array($key, $this->fillable ?? []) ||
+               array_key_exists($key, $this->casts ?? []);
     }
 
     /**


### PR DESCRIPTION
## Summary
- align CommonQueryScopes hasAttribute signature with Eloquent model to prevent fatal errors during package discovery
- reuse parent hasAttribute when available before falling back to fillable and casts checks

## Testing
- php -l app/Models/Traits/CommonQueryScopes.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d8d924318833382d65e8e97df1835)