### PR TITLE
Guard cache tables creation in core migration

### DIFF
--- a/database/migrations/2026_01_04_000001_create_core_tables.php
+++ b/database/migrations/2026_01_04_000001_create_core_tables.php
@@ -31,19 +31,23 @@ return new class extends Migration
     public function up(): void
     {
         // Cache tables (Laravel default)
-        Schema::create('cache', function (Blueprint $table) {
-            $this->setTableOptions($table);
-            $table->string('key', 255)->primary();
-            $table->mediumText('value');
-            $table->integer('expiration');
-        });
+        if (! Schema::hasTable('cache')) {
+            Schema::create('cache', function (Blueprint $table) {
+                $this->setTableOptions($table);
+                $table->string('key', 255)->primary();
+                $table->mediumText('value');
+                $table->integer('expiration');
+            });
+        }
 
-        Schema::create('cache_locks', function (Blueprint $table) {
-            $this->setTableOptions($table);
-            $table->string('key', 255)->primary();
-            $table->string('owner', 255);
-            $table->integer('expiration');
-        });
+        if (! Schema::hasTable('cache_locks')) {
+            Schema::create('cache_locks', function (Blueprint $table) {
+                $this->setTableOptions($table);
+                $table->string('key', 255)->primary();
+                $table->string('owner', 255);
+                $table->integer('expiration');
+            });
+        }
 
         // Jobs tables
         Schema::create('jobs', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- add table existence checks before creating cache and cache_locks tables in the core migration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d8fbda78083339f54bd7a6ecf3d89)